### PR TITLE
fix: normalize package metadata to @opensin/code (#23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "name": "opencode",
+  "name": "@opensin/code",
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
@@ -94,7 +94,7 @@
     "type": "git",
     "url": "https://github.com/anomalyco/opencode"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "prettier": {
     "semi": false,
     "printWidth": 120

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "version": "1.3.13",
-  "name": "opencode",
+  "name": "@opensin/code",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE",
   "private": true,


### PR DESCRIPTION
Fixes #23

- packages/opencode/package.json: name opencode → @opensin/code
- root package.json: name opencode → @opensin/code, license MIT → SEE LICENSE IN LICENSE