### PR TITLE
fix: add root and CLI package.json with @opensin/code naming (#23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@opensin/code",
+  "version": "0.0.0",
+  "description": "SIN Code CLI — The autonomous coding CLI powered by OpenCode",
+  "license": "SEE LICENSE IN LICENSE",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "workspaces": [
+    "packages/*",
+    "packages/sdk/*"
+  ],
+  "scripts": {
+    "dev": "node packages/opencode/src/bin/opencode.js",
+    "build": "npm run build --workspace=packages/opencode",
+    "test": "npm run test --workspace=packages/opencode",
+    "lint": "npm run lint --workspace=packages/opencode"
+  }
+}

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@opensin/code",
+  "version": "0.0.0",
+  "description": "SIN Code CLI — The autonomous coding CLI",
+  "license": "SEE LICENSE IN LICENSE",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "sincode": "./dist/bin/opencode.js",
+    "sin": "./dist/bin/opencode.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "dev": "node src/bin/opencode.js",
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  }
+}


### PR DESCRIPTION
Fixes #23

- Created root package.json with name @opensin/code, license SEE LICENSE IN LICENSE
- Created packages/opencode/package.json with name @opensin/code, license SEE LICENSE IN LICENSE
- Binary aliases: sincode, sin