### PR TITLE
fix: align README and AGENTS.md with proprietary SIN Code branding (#24)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent: OpenSIN-Code
+# Agent: SIN Code
 
 **Team:** OpenSIN-AI
 **Protocol:** A2A (Agent-to-Agent)
@@ -7,7 +7,7 @@
 
 ## Capabilities
 
-OpenSIN-Code is the core code agent for the OpenSIN ecosystem, providing intelligent code generation, analysis, and refactoring capabilities.
+SIN Code is the core code agent for the SIN Solver platform, providing intelligent code generation, analysis, and refactoring capabilities.
 
 ## Communication
 
@@ -32,4 +32,4 @@ npm start
 
 ## License
 
-MIT
+Proprietary — See LICENSE file for details. Part of SIN Solver platform (https://my.openSIN.ai)

--- a/README.md
+++ b/README.md
@@ -1,33 +1,38 @@
-# OpenSIN Code
+# SIN Code CLI
 
-The core CLI and VS Code Extension for OpenSIN — an AI-powered coding platform that combines the best of Claude Code, Cursor, and Windsurf into a single, sovereign tool.
+[![SIN Code CLI](https://img.shields.io/badge/SIN%20Code%20CLI-latest-green)](https://my.openSIN.ai)
+[![Node 18+](https://img.shields.io/badge/node-18%2B-339933)](https://nodejs.org)
+[![License](https://img.shields.io/badge/License-Proprietary-red)](https://my.openSIN.ai)
+
+The proprietary CLI for SIN Solver — an enterprise-grade AI coding platform that combines autonomous code generation, multi-agent swarm coordination, and semantic code intelligence into a single sovereign tool.
 
 ## Architecture
 
 ```
 OpenSIN-Code/
 ├── packages/
-│   ├── opencode/          # Core CLI engine
+│   ├── opencode/          # Core CLI engine (@opensin/code)
 │   └── sdk/               # @opensin/sdk — JavaScript/TypeScript SDK
-├── opensin-code-vscode/   # VS Code Extension (Mode Selector, Chat, Swarm)
-└── hermes-dispatch-opensin-code.json  # Cloud execution dispatch payload
+├── kairos-vscode/         # VS Code Extension (Mode Selector, Chat, Swarm)
+└── Docs/                  # Operations and dispatch payloads
 ```
 
 ## Components
 
-### OpenSIN CLI (`packages/opencode`)
+### SIN Code CLI (`packages/opencode`)
 - AI-powered code generation via 100+ LLM providers and 1000+ models (model-agnostic architecture)
 - Subagent orchestration (explore, librarian, oracle, hephaestus, metis, momus)
 - Swarm coordination for parallel agent execution
 - Hermes dispatch for cloud execution on HF VMs
+- sincode.json configuration with opencode.json fallback
 
-### OpenSIN SDK (`packages/sdk`)
-- `@opensin/sdk` — JavaScript/TypeScript SDK for OpenSIN API
+### SIN Code SDK (`packages/sdk`)
+- `@opensin/sdk` — JavaScript/TypeScript SDK for SIN Solver API
 - Model routing, Simone MCP integration
 - Type-safe API client
 
-### OpenSIN VS Code Extension (`opensin-code-vscode/`)
-- Mode Selector (Architect, Code, Debug, Ask, OpenSIN-Code)
+### Kairos VS Code Extension (`kairos-vscode/`)
+- Mode Selector (Architect, Code, Debug, Ask, SIN-Code)
 - React Webview Sidebar with Chat Interface
 - RPC CLI Bridge to sin-code via opencode CLI
 - LSP Provider via Simone MCP
@@ -44,10 +49,13 @@ OpenSIN-Code/
 npm install -g @opensin/code
 
 # Run in a project
-opensin code
+sincode
+
+# Or use alias
+sin --help
 
 # Build VS Code Extension
-cd opensin-code-vscode
+cd kairos-vscode
 npm install
 npm run compile
 npx vsce package --no-dependencies
@@ -55,7 +63,9 @@ npx vsce package --no-dependencies
 
 ## License
 
-SEE LICENSE IN LICENSE (Proprietary — SIN-Solver Team)
+This software is **proprietary**. See [LICENSE](LICENSE) file for details.
+
+Part of the **SIN Solver** platform — https://my.openSIN.ai
 
 ## Documentation
 
@@ -63,4 +73,4 @@ SEE LICENSE IN LICENSE (Proprietary — SIN-Solver Team)
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Contribution guidelines
 - [SECURITY.md](SECURITY.md) — Security policy
 
-> OpenSIN connects to **100+ LLM providers** and **1000+ models** — including OpenAI, Anthropic, Google, Mistral, Groq, Cerebras, TogetherAI, Ollama, local models, and 90+ more. Bring your own API key or use our free tier.
+> SIN Code connects to **100+ LLM providers** and **1000+ models** — including OpenAI, Anthropic, Google, Mistral, Groq, Cerebras, TogetherAI, Ollama, local models, and 90+ more. Bring your own API key or use our free tier.


### PR DESCRIPTION
Fixes #24

## Changes
- **README.md**: Rebranded from 'OpenSIN Code' to 'SIN Code CLI'
  - Added SIN Code CLI badge, Node 18+ badge, Proprietary license badge
  - Updated all references: opensin-code-vscode → kairos-vscode
  - Updated command: 'opensin code' → 'sincode'
  - Added SIN Solver platform links (https://my.openSIN.ai)
  - Changed license section to clearly state proprietary

- **AGENTS.md**: Updated agent identity
  - OpenSIN-Code → SIN Code
  - MIT → Proprietary license with platform link