### PR TITLE
Phase 2.1: CLI Core Agent Loop — Query → API → Tools → Repeat

### DIFF
--- a/packages/opensin-sdk/src/__tests__/agent_loop.test.ts
+++ b/packages/opensin-sdk/src/__tests__/agent_loop.test.ts
@@ -1,0 +1,901 @@
+/**
+ * OpenSIN Agent Loop — Comprehensive Tests
+ *
+ * Tests for:
+ * - Core loop runs continuously
+ * - Handles tool results correctly
+ * - Streams NDJSON output
+ * - Error recovery works (retry logic)
+ * - Context window management
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AgentLoop, createAgentLoop } from '../agent_loop/agent_loop.js';
+import { ToolRegistry, createToolRegistry } from '../agent_loop/tool_registry.js';
+import { AgentLoopContext, estimateMessageTokens, estimateTotalTokens } from '../agent_loop/context.js';
+import {
+  toNDJSONLine,
+  emitNDJSON,
+  makeEvent,
+  parseNDJSONLine,
+  parseNDJSONStream,
+  streamNDJSON,
+} from '../agent_loop/ndjson.js';
+import type {
+  AgentLoopConfig,
+  LLMCaller,
+  LLMResponse,
+  AgentEvent,
+} from '../agent_loop/types.js';
+import type { Message, ToolCall, ToolResult, ToolDefinition } from '../types.js';
+
+// --- Helpers ---
+
+function createMockLLMCaller(responses: LLMResponse[]): LLMCaller {
+  let callIndex = 0;
+  return async (): Promise<LLMResponse> => {
+    if (callIndex >= responses.length) {
+      return {
+        content: 'No more responses configured',
+        toolCalls: [],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        stopReason: 'end_turn',
+      };
+    }
+    return responses[callIndex++]!;
+  };
+}
+
+function createFailingLLMCaller(failCount: number, successResponse: LLMResponse): LLMCaller {
+  let callIndex = 0;
+  return async (): Promise<LLMResponse> => {
+    callIndex++;
+    if (callIndex <= failCount) {
+      throw new Error(`Transient error #${callIndex} — rate limit exceeded`);
+    }
+    return successResponse;
+  };
+}
+
+function createToolCall(name: string, input: Record<string, unknown> = {}): ToolCall {
+  return {
+    id: `tc-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    input,
+  };
+}
+
+function createToolResult(output: string, isError = false): ToolResult {
+  return {
+    output,
+    is_error: isError,
+    metadata: {},
+  };
+}
+
+function createToolDefinition(name: string): ToolDefinition {
+  return {
+    name,
+    description: `Test tool: ${name}`,
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  };
+}
+
+// Capture stdout for NDJSON tests
+function captureStdout(): { output: string; restore: () => void } {
+  let output = '';
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk: string | Uint8Array): boolean => {
+    if (typeof chunk === 'string') {
+      output += chunk;
+    }
+    return true;
+  };
+  return {
+    output: '',
+    restore: () => {
+      process.stdout.write = originalWrite;
+    },
+  };
+}
+
+// --- NDJSON Tests ---
+
+describe('NDJSON Streaming', () => {
+  it('serializes an event to NDJSON', () => {
+    const event = makeEvent('status', { status: 'running' }, 'turn-1');
+    const line = toNDJSONLine(event);
+    const parsed = JSON.parse(line);
+    expect(parsed.type).toBe('status');
+    expect(parsed.status).toBe('running');
+    expect(parsed.turn).toBe('turn-1');
+    expect(typeof parsed.ts).toBe('string');
+  });
+
+  it('parses a valid NDJSON line', () => {
+    const line = JSON.stringify({ type: 'text_delta', ts: '2026-01-01T00:00:00Z', content: 'hello' });
+    const event = parseNDJSONLine(line);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('text_delta');
+    expect(event!.data.content).toBe('hello');
+  });
+
+  it('returns null for invalid NDJSON', () => {
+    expect(parseNDJSONLine('not json')).toBeNull();
+    expect(parseNDJSONLine('')).toBeNull();
+    expect(parseNDJSONLine('   ')).toBeNull();
+  });
+
+  it('parses multiple NDJSON lines', () => {
+    const lines = [
+      JSON.stringify({ type: 'status', ts: 't1', status: 'start' }),
+      JSON.stringify({ type: 'thinking', ts: 't2', message: 'hello' }),
+      JSON.stringify({ type: 'text_delta', ts: 't3', content: 'world' }),
+    ].join('\n');
+
+    const events = parseNDJSONStream(lines);
+    expect(events).toHaveLength(3);
+    expect(events[0].type).toBe('status');
+    expect(events[1].type).toBe('thinking');
+    expect(events[2].type).toBe('text_delta');
+  });
+
+  it('skips empty lines in NDJSON stream', () => {
+    const lines = [
+      JSON.stringify({ type: 'status', ts: 't1' }),
+      '',
+      '',
+      JSON.stringify({ type: 'done', ts: 't2' }),
+    ].join('\n');
+
+    const events = parseNDJSONStream(lines);
+    expect(events).toHaveLength(2);
+  });
+
+  it('makeEvent creates proper event structure', () => {
+    const event = makeEvent('tool_call_start', { tool_name: 'bash', tool_id: 'tc-1' }, 'turn-1');
+    expect(event.type).toBe('tool_call_start');
+    expect(event.turnId).toBe('turn-1');
+    expect(event.data.tool_name).toBe('bash');
+    expect(event.data.tool_id).toBe('tc-1');
+    expect(typeof event.timestamp).toBe('string');
+  });
+});
+
+// --- Tool Registry Tests ---
+
+describe('Tool Registry', () => {
+  it('registers and retrieves tools', () => {
+    const registry = createToolRegistry();
+    const def = createToolDefinition('bash');
+    registry.register('bash', {
+      definition: def,
+      execute: async () => createToolResult('ok'),
+    });
+
+    expect(registry.has('bash')).toBe(true);
+    expect(registry.get('bash')).toBeDefined();
+    expect(registry.getDefinitions()).toHaveLength(1);
+    expect(registry.getNames()).toEqual(['bash']);
+  });
+
+  it('executes a registered tool', async () => {
+    const registry = createToolRegistry();
+    registry.register('bash', {
+      definition: createToolDefinition('bash'),
+      execute: async (tc) => createToolResult(`executed: ${tc.input.command}`),
+    });
+
+    const tc = createToolCall('bash', { command: 'ls -la' });
+    const result = await registry.execute(tc, '/workspace', 'session-1');
+    expect(result.is_error).toBe(false);
+    expect(result.output).toBe('executed: ls -la');
+  });
+
+  it('returns error for unknown tool', async () => {
+    const registry = createToolRegistry();
+    const tc = createToolCall('nonexistent');
+    const result = await registry.execute(tc, '/workspace', 'session-1');
+    expect(result.is_error).toBe(true);
+    expect(result.output).toContain('Unknown tool');
+  });
+
+  it('handles tool execution errors', async () => {
+    const registry = createToolRegistry();
+    registry.register('failing', {
+      definition: createToolDefinition('failing'),
+      execute: async () => { throw new Error('Tool crashed'); },
+    });
+
+    const tc = createToolCall('failing');
+    const result = await registry.execute(tc, '/workspace', 'session-1');
+    expect(result.is_error).toBe(true);
+    expect(result.output).toContain('Tool crashed');
+  });
+
+  it('unregisters tools', () => {
+    const registry = createToolRegistry();
+    registry.register('temp', {
+      definition: createToolDefinition('temp'),
+      execute: async () => createToolResult('ok'),
+    });
+    expect(registry.has('temp')).toBe(true);
+    registry.unregister('temp');
+    expect(registry.has('temp')).toBe(false);
+  });
+});
+
+// --- Context Management Tests ---
+
+describe('Context Window Management', () => {
+  it('estimates tokens for messages', () => {
+    const msg: Message = { role: 'user', content: 'Hello world' };
+    const tokens = estimateMessageTokens(msg);
+    expect(tokens).toBeGreaterThan(0);
+    expect(tokens).toBe(Math.ceil('Hello world'.length / 4));
+  });
+
+  it('estimates total tokens for message array', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+    const total = estimateTotalTokens(messages);
+    expect(total).toBe(Math.ceil(5 / 4) + Math.ceil(8 / 4));
+  });
+
+  it('creates context and tracks utilization', () => {
+    const config: AgentLoopConfig = {
+      maxToolIterations: 10,
+      maxRetries: 3,
+      retryBaseDelayMs: 100,
+      retryMaxDelayMs: 1000,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+      streamNDJSON: false,
+      model: 'test-model',
+      workspace: '/tmp',
+      permissionMode: 'auto',
+    };
+    const ctx = new AgentLoopContext('test-session', config);
+    ctx.addMessage({ role: 'user', content: 'Hello world' });
+
+    const stats = ctx.getStats();
+    expect(stats.messageCount).toBe(1);
+    expect(stats.totalTokens).toBeGreaterThan(0);
+    expect(stats.utilization).toBeGreaterThanOrEqual(0);
+  });
+
+  it('adds system messages with highest priority', () => {
+    const config: AgentLoopConfig = {
+      maxToolIterations: 10,
+      maxRetries: 3,
+      retryBaseDelayMs: 100,
+      retryMaxDelayMs: 1000,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+      streamNDJSON: false,
+      model: 'test-model',
+      workspace: '/tmp',
+      permissionMode: 'auto',
+    };
+    const ctx = new AgentLoopContext('test-session', config);
+    ctx.addSystemMessage('You are a helpful assistant');
+    ctx.addMessage({ role: 'user', content: 'Hello' });
+
+    const messages = ctx.getMessages();
+    expect(messages[0].role).toBe('assistant');
+    expect(messages[0].content).toContain('[SYSTEM]');
+    expect(messages[0].content).toContain('You are a helpful assistant');
+    expect(messages[1].role).toBe('user');
+  });
+
+  it('clears conversation but keeps system messages', () => {
+    const config: AgentLoopConfig = {
+      maxToolIterations: 10,
+      maxRetries: 3,
+      retryBaseDelayMs: 100,
+      retryMaxDelayMs: 1000,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+      streamNDJSON: false,
+      model: 'test-model',
+      workspace: '/tmp',
+      permissionMode: 'auto',
+    };
+    const ctx = new AgentLoopContext('test-session', config);
+    ctx.addSystemMessage('System prompt');
+    ctx.addMessage({ role: 'user', content: 'Hello' });
+    ctx.addMessage({ role: 'assistant', content: 'Hi' });
+
+    ctx.clearConversation();
+    const messages = ctx.getMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('assistant');
+    expect(messages[0].content).toContain('[SYSTEM]');
+  });
+
+  it('compresses context when needed', () => {
+    const config: AgentLoopConfig = {
+      maxToolIterations: 10,
+      maxRetries: 3,
+      retryBaseDelayMs: 100,
+      retryMaxDelayMs: 1000,
+      maxContextTokens: 100,
+      compressionThreshold: 0.5,
+      streamNDJSON: false,
+      model: 'test-model',
+      workspace: '/tmp',
+      permissionMode: 'auto',
+    };
+    const ctx = new AgentLoopContext('test-session', config);
+    ctx.addSystemMessage('System');
+
+    // Add many messages to trigger compression
+    for (let i = 0; i < 20; i++) {
+      ctx.addMessage({ role: 'user', content: `User message ${i} with some content to add tokens` });
+      ctx.addMessage({ role: 'assistant', content: `Assistant response ${i} with some content to add tokens` });
+    }
+
+    const before = ctx.getTotalTokens();
+    const saved = ctx.compress();
+    const after = ctx.getTotalTokens();
+
+    expect(saved).toBeGreaterThanOrEqual(0);
+    expect(after).toBeLessThanOrEqual(before);
+  });
+});
+
+// --- Core Agent Loop Tests ---
+
+describe('Core Agent Loop', () => {
+  it('runs a simple turn without tool calls', async () => {
+    const registry = createToolRegistry();
+    const caller = createMockLLMCaller([
+      {
+        content: 'Hello! How can I help you?',
+        toolCalls: [],
+        usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 2,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Hello', 'test-session');
+
+    expect(result.finalContent).toBe('Hello! How can I help you?');
+    expect(result.toolCallsExecuted).toBe(0);
+    expect(result.iterations).toBe(1);
+    expect(result.totalTokens.total_tokens).toBe(30);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('handles tool calls and re-injects results', async () => {
+    const registry = createToolRegistry();
+    registry.register('read_file', {
+      definition: createToolDefinition('read_file'),
+      execute: async () => createToolResult('file contents here'),
+    });
+
+    const caller = createMockLLMCaller([
+      {
+        content: '',
+        toolCalls: [createToolCall('read_file', { path: 'test.txt' })],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        stopReason: 'tool_use',
+      },
+      {
+        content: 'The file contains: file contents here',
+        toolCalls: [],
+        usage: { input_tokens: 20, output_tokens: 15, total_tokens: 35 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 2,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Read test.txt', 'test-session');
+
+    expect(result.toolCallsExecuted).toBe(1);
+    expect(result.iterations).toBe(2);
+    expect(result.finalContent).toBe('The file contains: file contents here');
+    expect(result.totalTokens.total_tokens).toBe(50);
+  });
+
+  it('handles multiple tool calls in one response', async () => {
+    const registry = createToolRegistry();
+    registry.register('read_file', {
+      definition: createToolDefinition('read_file'),
+      execute: async (tc) => createToolResult(`contents of ${tc.input.path}`),
+    });
+    registry.register('grep', {
+      definition: createToolDefinition('grep'),
+      execute: async (tc) => createToolResult(`grep results for ${tc.input.pattern}`),
+    });
+
+    const caller = createMockLLMCaller([
+      {
+        content: '',
+        toolCalls: [
+          createToolCall('read_file', { path: 'a.txt' }),
+          createToolCall('grep', { pattern: 'foo' }),
+        ],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        stopReason: 'tool_use',
+      },
+      {
+        content: 'Found foo in a.txt',
+        toolCalls: [],
+        usage: { input_tokens: 20, output_tokens: 10, total_tokens: 30 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 2,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Search for foo', 'test-session');
+
+    expect(result.toolCallsExecuted).toBe(2);
+    expect(result.iterations).toBe(2);
+    expect(result.finalContent).toBe('Found foo in a.txt');
+  });
+
+  it('respects max tool iterations limit', async () => {
+    const registry = createToolRegistry();
+    registry.register('loop_tool', {
+      definition: createToolDefinition('loop_tool'),
+      execute: async () => createToolResult('looping'),
+    });
+
+    // Always returns a tool call — would loop forever without limit
+    const caller: LLMCaller = async () => ({
+      content: '',
+      toolCalls: [createToolCall('loop_tool')],
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      stopReason: 'tool_use',
+    });
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 3,
+      maxRetries: 1,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Loop forever', 'test-session');
+
+    expect(result.iterations).toBe(3);
+    expect(result.toolCallsExecuted).toBe(3);
+  });
+
+  it('can be cancelled mid-turn', async () => {
+    const registry = createToolRegistry();
+    registry.register('slow_tool', {
+      definition: createToolDefinition('slow_tool'),
+      execute: async () => {
+        await new Promise(r => setTimeout(r, 50));
+        return createToolResult('done');
+      },
+    });
+
+    const caller: LLMCaller = async () => ({
+      content: '',
+      toolCalls: [createToolCall('slow_tool')],
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      stopReason: 'tool_use',
+    });
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 10,
+      maxRetries: 1,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+
+    // Cancel after a short delay
+    setTimeout(() => loop.cancel(), 30);
+
+    const result = await loop.processTurn('Cancel me', 'test-session');
+    expect(result.iterations).toBeLessThanOrEqual(10);
+  });
+});
+
+// --- Error Recovery / Retry Tests ---
+
+describe('Error Recovery & Retry Logic', () => {
+  it('retries on transient LLM errors and succeeds', async () => {
+    const registry = createToolRegistry();
+    const caller = createFailingLLMCaller(2, {
+      content: 'Success after retries',
+      toolCalls: [],
+      usage: { input_tokens: 10, output_tokens: 20, total_tokens: 30 },
+      stopReason: 'end_turn',
+    });
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Hello', 'test-session');
+
+    expect(result.finalContent).toBe('Success after retries');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('fails after exhausting retries', async () => {
+    const registry = createToolRegistry();
+    const caller = createFailingLLMCaller(10, {
+      content: 'Never reached',
+      toolCalls: [],
+      usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+      stopReason: 'end_turn',
+    });
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 2,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Hello', 'test-session');
+
+    expect(result.error).toBeDefined();
+    expect(result.finalContent).toBe('');
+  });
+
+  it('does not retry on non-transient errors', async () => {
+    const registry = createToolRegistry();
+    const caller: LLMCaller = async () => {
+      throw new Error('Invalid API key — permanent failure');
+    };
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Hello', 'test-session');
+
+    expect(result.error).toContain('Invalid API key');
+  });
+
+  it('handles tool execution errors gracefully', async () => {
+    const registry = createToolRegistry();
+    registry.register('crash_tool', {
+      definition: createToolDefinition('crash_tool'),
+      execute: async () => { throw new Error('Tool crashed hard'); },
+    });
+
+    const caller = createMockLLMCaller([
+      {
+        content: '',
+        toolCalls: [createToolCall('crash_tool')],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        stopReason: 'tool_use',
+      },
+      {
+        content: 'The tool failed, but I can still respond',
+        toolCalls: [],
+        usage: { input_tokens: 20, output_tokens: 15, total_tokens: 35 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 1,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    const result = await loop.processTurn('Use crash tool', 'test-session');
+
+    // The loop should continue even after tool failure
+    expect(result.iterations).toBe(2);
+    expect(result.finalContent).toBe('The tool failed, but I can still respond');
+  });
+});
+
+// --- NDJSON Streaming Integration Tests ---
+
+describe('NDJSON Streaming Integration', () => {
+  it('emits NDJSON events during a turn', async () => {
+    const registry = createToolRegistry();
+    const caller = createMockLLMCaller([
+      {
+        content: 'Hello back',
+        toolCalls: [],
+        usage: { input_tokens: 10, output_tokens: 10, total_tokens: 20 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    // Capture NDJSON output
+    let ndjsonOutput = '';
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === 'string') {
+        ndjsonOutput += chunk;
+      }
+      return true;
+    };
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: true,
+      maxToolIterations: 5,
+      maxRetries: 1,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    await loop.processTurn('Hello', 'test-session');
+
+    // Restore stdout
+    process.stdout.write = originalWrite;
+
+    // Parse the NDJSON output
+    const events = parseNDJSONStream(ndjsonOutput);
+    expect(events.length).toBeGreaterThan(0);
+
+    // Should have session_start, status, thinking, text_delta, turn_complete, session_end
+    const types = events.map(e => e.type);
+    expect(types).toContain('session_start');
+    expect(types).toContain('status');
+    expect(types).toContain('thinking');
+    expect(types).toContain('text_delta');
+    expect(types).toContain('turn_complete');
+    expect(types).toContain('session_end');
+  });
+
+  it('emits tool_call events during tool execution', async () => {
+    const registry = createToolRegistry();
+    registry.register('echo', {
+      definition: createToolDefinition('echo'),
+      execute: async (tc) => createToolResult(String(tc.input.text)),
+    });
+
+    const caller = createMockLLMCaller([
+      {
+        content: '',
+        toolCalls: [createToolCall('echo', { text: 'hello' })],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        stopReason: 'tool_use',
+      },
+      {
+        content: 'Echo result: hello',
+        toolCalls: [],
+        usage: { input_tokens: 15, output_tokens: 10, total_tokens: 25 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    let ndjsonOutput = '';
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === 'string') {
+        ndjsonOutput += chunk;
+      }
+      return true;
+    };
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: true,
+      maxToolIterations: 5,
+      maxRetries: 1,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    await loop.processTurn('Echo hello', 'test-session');
+
+    process.stdout.write = originalWrite;
+
+    const events = parseNDJSONStream(ndjsonOutput);
+    const types = events.map(e => e.type);
+    expect(types).toContain('tool_call_start');
+    expect(types).toContain('tool_call_end');
+    expect(types).toContain('tool_result');
+  });
+
+  it('emits retry events on transient errors', async () => {
+    const registry = createToolRegistry();
+    const caller = createFailingLLMCaller(1, {
+      content: 'Recovered',
+      toolCalls: [],
+      usage: { input_tokens: 10, output_tokens: 10, total_tokens: 20 },
+      stopReason: 'end_turn',
+    });
+
+    let ndjsonOutput = '';
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === 'string') {
+        ndjsonOutput += chunk;
+      }
+      return true;
+    };
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: true,
+      maxToolIterations: 5,
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+    await loop.processTurn('Hello', 'test-session');
+
+    process.stdout.write = originalWrite;
+
+    const events = parseNDJSONStream(ndjsonOutput);
+    const types = events.map(e => e.type);
+    expect(types).toContain('retry');
+  });
+});
+
+// --- Async NDJSON Stream Tests ---
+
+describe('NDJSON Async Stream', () => {
+  it('parses events from an async string stream', async () => {
+    async function* generateLines() {
+      yield JSON.stringify({ type: 'status', ts: 't1', status: 'start' }) + '\n';
+      yield JSON.stringify({ type: 'text_delta', ts: 't2', content: 'hello' }) + '\n';
+      yield JSON.stringify({ type: 'done', ts: 't3' }) + '\n';
+    }
+
+    const events: AgentEvent[] = [];
+    for await (const event of streamNDJSON(generateLines())) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(3);
+    expect(events[0].type).toBe('status');
+    expect(events[1].type).toBe('text_delta');
+    expect(events[2].type).toBe('done');
+  });
+
+  it('handles partial lines across chunks', async () => {
+    async function* generateLines() {
+      // Split a JSON line across two chunks
+      yield '{"type": "status", "ts": "t1", "st';
+      yield 'atus": "start"}\n';
+    }
+
+    const events: AgentEvent[] = [];
+    for await (const event of streamNDJSON(generateLines())) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('status');
+  });
+});
+
+// --- Turn State Tests ---
+
+describe('Turn State', () => {
+  it('tracks turn state during execution', async () => {
+    const registry = createToolRegistry();
+    const caller = createMockLLMCaller([
+      {
+        content: 'Done',
+        toolCalls: [],
+        usage: { input_tokens: 10, output_tokens: 10, total_tokens: 20 },
+        stopReason: 'end_turn',
+      },
+    ]);
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+      maxToolIterations: 5,
+      maxRetries: 1,
+      retryBaseDelayMs: 10,
+      retryMaxDelayMs: 100,
+      maxContextTokens: 1000,
+      compressionThreshold: 0.8,
+    });
+
+    loop.init('test-session');
+
+    // Before processing
+    expect(loop.getTurnState()).toBeNull();
+    expect(loop.isRunning()).toBe(false);
+
+    // During processing (we can't easily test this synchronously, but we can check after)
+    const result = await loop.processTurn('Hello', 'test-session');
+
+    // After processing
+    const state = loop.getTurnState();
+    expect(state).not.toBeNull();
+    expect(state!.status).toBe('completed');
+    expect(state!.iterationCount).toBe(1);
+    expect(state!.turnId).toBe(result.turnId);
+    expect(loop.isRunning()).toBe(false);
+  });
+
+  it('provides access to context and tool registry', () => {
+    const registry = createToolRegistry();
+    const caller = createMockLLMCaller([]);
+
+    const loop = createAgentLoop(caller, registry, {
+      streamNDJSON: false,
+    });
+
+    expect(loop.getToolRegistry()).toBe(registry);
+    expect(loop.getContext()).toBeNull();
+
+    loop.init('test-session');
+    expect(loop.getContext()).not.toBeNull();
+  });
+});

--- a/packages/opensin-sdk/src/agent_loop/agent_loop.ts
+++ b/packages/opensin-sdk/src/agent_loop/agent_loop.ts
@@ -1,0 +1,515 @@
+/**
+ * OpenSIN Agent Loop — Core Agent Loop
+ *
+ * The heart of the OpenSIN CLI: Query input → API call → Tool execution → Response loop.
+ *
+ * Features:
+ * - NDJSON streaming output
+ * - Exponential backoff retry on transient errors
+ * - Tool result processing and re-injection
+ * - Context window management with auto-compression
+ * - Continuous loop until final response (no tool calls remaining)
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+  Message,
+  ToolCall,
+  ToolResult,
+  ToolDefinition,
+  TokenUsage,
+  StreamChunk,
+} from '../types.js';
+import {
+  AgentLoopConfig,
+  DEFAULT_AGENT_LOOP_CONFIG,
+  AgentLoopResult,
+  TurnState,
+  LLMCaller,
+  LLMResponse,
+  ToolExecutor,
+  AgentEventType,
+} from './types.js';
+import { emitNDJSON, makeEvent } from './ndjson.js';
+import { ToolRegistry } from './tool_registry.js';
+import { AgentLoopContext } from './context.js';
+
+/**
+ * Check if an error is transient (retryable).
+ */
+function isTransientError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const transientPatterns = [
+    /rate.?limit/i,
+    /too many requests/i,
+    /429/i,
+    /503/i,
+    /502/i,
+    /504/i,
+    /timeout/i,
+    /network/i,
+    /ECONNREFUSED/i,
+    /ECONNRESET/i,
+    /ETIMEDOUT/i,
+    /service unavailable/i,
+    /overloaded/i,
+  ];
+  return transientPatterns.some(pattern => pattern.test(message));
+}
+
+/**
+ * Calculate exponential backoff delay.
+ */
+function calculateBackoff(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const delay = baseDelayMs * Math.pow(2, attempt);
+  // Add jitter (±25%)
+  const jitter = delay * 0.25 * (Math.random() * 2 - 1);
+  return Math.min(delay + jitter, maxDelayMs);
+}
+
+/**
+ * Sleep for a given number of milliseconds.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Build the default tool definitions for the agent loop.
+ */
+function buildDefaultToolDefinitions(registry: ToolRegistry): ToolDefinition[] {
+  return registry.getDefinitions();
+}
+
+/**
+ * The core OpenSIN Agent Loop.
+ *
+ * Manages the continuous cycle of:
+ * 1. Send messages to LLM
+ * 2. Parse response (text + tool calls)
+ * 3. Execute tool calls
+ * 4. Feed results back to LLM
+ * 5. Repeat until no more tool calls
+ */
+export class AgentLoop {
+  private config: AgentLoopConfig;
+  private llmCaller: LLMCaller;
+  private toolRegistry: ToolRegistry;
+  private context: AgentLoopContext | null = null;
+  private currentTurn: TurnState | null = null;
+  private running = false;
+  private cancelled = false;
+
+  constructor(
+    llmCaller: LLMCaller,
+    toolRegistry: ToolRegistry,
+    config?: Partial<AgentLoopConfig>,
+  ) {
+    this.llmCaller = llmCaller;
+    this.toolRegistry = toolRegistry;
+    this.config = { ...DEFAULT_AGENT_LOOP_CONFIG, ...config };
+  }
+
+  /**
+   * Initialize the agent loop for a session.
+   */
+  init(sessionId: string): void {
+    this.context = new AgentLoopContext(sessionId, this.config);
+    this.running = false;
+    this.cancelled = false;
+  }
+
+  /**
+   * Add a system message to the context.
+   */
+  setSystemMessage(content: string): void {
+    if (!this.context) {
+      throw new Error('Agent loop not initialized. Call init() first.');
+    }
+    this.context.addSystemMessage(content);
+  }
+
+  /**
+   * Process a user query through the full agent loop.
+   *
+   * This is the main entry point. It:
+   * 1. Adds the user message to context
+   * 2. Calls the LLM
+   * 3. Executes any tool calls
+   * 4. Repeats until the LLM produces a final text response
+   * 5. Streams NDJSON events throughout
+   */
+  async processTurn(
+    userMessage: string,
+    sessionId: string,
+  ): Promise<AgentLoopResult> {
+    if (!this.context) {
+      throw new Error('Agent loop not initialized. Call init() first.');
+    }
+
+    const turnId = randomUUID();
+    this.currentTurn = {
+      turnId,
+      messages: this.context.getMessages(),
+      toolCalls: [],
+      toolResults: [],
+      iterationCount: 0,
+      retryCount: 0,
+      totalTokens: 0,
+      startTime: Date.now(),
+      status: 'running',
+    };
+
+    this.running = true;
+    this.cancelled = false;
+
+    // Emit session start event
+    this.emit('session_start', { sessionId, turnId });
+    this.emit('status', { status: 'starting', turnId });
+
+    // Add user message to context
+    const userMsg: Message = { role: 'user', content: userMessage };
+    this.context.addMessage(userMsg);
+
+    // Emit thinking event
+    this.emit('thinking', { message: userMessage, turnId });
+
+    let finalContent = '';
+    let toolCallsExecuted = 0;
+    let totalUsage: TokenUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+
+    try {
+      // Main loop: keep going while LLM returns tool calls
+      while (this.currentTurn.iterationCount < this.config.maxToolIterations) {
+        if (this.cancelled) {
+          this.currentTurn.status = 'cancelled';
+          break;
+        }
+
+        this.currentTurn.iterationCount++;
+        this.emit('status', {
+          status: 'iterating',
+          iteration: this.currentTurn.iterationCount,
+          turnId,
+        });
+
+        // Call LLM with retry
+        let llmResponse: LLMResponse;
+        try {
+          llmResponse = await this.callLLMWithRetry(
+            this.context.getMessages(),
+            buildDefaultToolDefinitions(this.toolRegistry),
+            turnId,
+          );
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          this.emit('error', { message: errorMsg, turnId, fatal: true });
+          this.currentTurn.status = 'error';
+          this.currentTurn.error = errorMsg;
+          return this.buildResult(turnId, finalContent, toolCallsExecuted, totalUsage, errorMsg);
+        }
+
+        // Accumulate usage
+        totalUsage.input_tokens += llmResponse.usage.input_tokens;
+        totalUsage.output_tokens += llmResponse.usage.output_tokens;
+        totalUsage.total_tokens += llmResponse.usage.total_tokens;
+        this.currentTurn.totalTokens = totalUsage.total_tokens;
+
+        // Handle the LLM response
+        if (llmResponse.content) {
+          finalContent = llmResponse.content;
+          this.emit('text_delta', { content: llmResponse.content, turnId });
+
+          // Add assistant response to context
+          const assistantMsg: Message = { role: 'assistant', content: llmResponse.content };
+          this.context.addMessage(assistantMsg);
+        }
+
+        // Check if there are tool calls to execute
+        if (llmResponse.toolCalls.length === 0) {
+          // No more tool calls — we're done
+          this.emit('status', { status: 'complete', turnId });
+          break;
+        }
+
+        // Execute tool calls
+        for (const toolCall of llmResponse.toolCalls) {
+          if (this.cancelled) break;
+
+          this.emit('tool_call_start', {
+            tool_name: toolCall.name,
+            tool_id: toolCall.id,
+            input: toolCall.input,
+            turnId,
+          });
+
+          // Execute the tool
+          const toolResult = await this.executeToolWithRetry(
+            toolCall,
+            this.config.workspace,
+            sessionId,
+            turnId,
+          );
+
+          this.currentTurn.toolCalls.push(toolCall);
+          this.currentTurn.toolResults.push(toolResult);
+          toolCallsExecuted++;
+
+          this.emit('tool_call_end', {
+            tool_name: toolCall.name,
+            tool_id: toolCall.id,
+            is_error: toolResult.is_error,
+            turnId,
+          });
+
+          this.emit('tool_result', {
+            tool_name: toolCall.name,
+            tool_id: toolCall.id,
+            output: toolResult.output,
+            is_error: toolResult.is_error,
+            turnId,
+          });
+
+          // Add tool result to context
+          const toolMsg: Message = {
+            role: 'tool',
+            content: toolResult.output,
+            tool_call_id: toolCall.id,
+          } as Message;
+          this.context.addMessage(toolMsg);
+        }
+
+        // Check context window and compress if needed
+        if (this.context.needsCompression()) {
+          const saved = this.context.compress();
+          this.emit('context_compressed', {
+            tokens_saved: saved,
+            remaining: this.context.getTotalTokens(),
+            turnId,
+          });
+        }
+      }
+
+      // Check if we hit max iterations
+      if (this.currentTurn.iterationCount >= this.config.maxToolIterations) {
+        this.emit('error', {
+          message: `Max tool iterations reached (${this.config.maxToolIterations})`,
+          turnId,
+          fatal: false,
+        });
+      }
+
+      this.currentTurn.status = this.currentTurn.status === 'running' ? 'completed' : this.currentTurn.status;
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      this.emit('error', { message: errorMsg, turnId, fatal: true });
+      this.currentTurn.status = 'error';
+      this.currentTurn.error = errorMsg;
+    }
+
+    this.running = false;
+
+    // Emit turn complete
+    this.emit('turn_complete', {
+      turnId,
+      finalContent,
+      toolCallsExecuted,
+      iterations: this.currentTurn.iterationCount,
+      totalTokens: totalUsage,
+      durationMs: Date.now() - this.currentTurn.startTime,
+    });
+
+    this.emit('session_end', { sessionId, turnId });
+
+    return this.buildResult(
+      turnId,
+      finalContent,
+      toolCallsExecuted,
+      totalUsage,
+      this.currentTurn.error,
+    );
+  }
+
+  /**
+   * Call the LLM with exponential backoff retry.
+   */
+  private async callLLMWithRetry(
+    messages: Message[],
+    tools: ToolDefinition[],
+    turnId: string,
+  ): Promise<LLMResponse> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      if (this.cancelled) {
+        throw new Error('Agent loop cancelled');
+      }
+
+      try {
+        return await this.llmCaller(messages, tools);
+      } catch (error) {
+        lastError = error;
+
+        if (!isTransientError(error) || attempt >= this.config.maxRetries) {
+          throw error;
+        }
+
+        const delay = calculateBackoff(
+          attempt,
+          this.config.retryBaseDelayMs,
+          this.config.retryMaxDelayMs,
+        );
+
+        this.currentTurn!.retryCount++;
+        this.emit('retry', {
+          attempt: attempt + 1,
+          maxRetries: this.config.maxRetries,
+          delayMs: Math.round(delay),
+          error: error instanceof Error ? error.message : String(error),
+          turnId,
+        });
+
+        await sleep(delay);
+      }
+    }
+
+    throw lastError;
+  }
+
+  /**
+   * Execute a tool call with retry logic.
+   */
+  private async executeToolWithRetry(
+    toolCall: ToolCall,
+    workspace: string,
+    sessionId: string,
+    turnId: string,
+  ): Promise<ToolResult> {
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      if (this.cancelled) {
+        return {
+          output: 'Tool execution cancelled',
+          is_error: true,
+          error_code: 499,
+        };
+      }
+
+      try {
+        return await this.toolRegistry.execute(toolCall, workspace, sessionId);
+      } catch (error) {
+        lastError = error;
+
+        if (!isTransientError(error) || attempt >= this.config.maxRetries) {
+          return {
+            output: `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`,
+            is_error: true,
+            error_code: 500,
+          };
+        }
+
+        const delay = calculateBackoff(
+          attempt,
+          this.config.retryBaseDelayMs,
+          this.config.retryMaxDelayMs,
+        );
+
+        this.emit('retry', {
+          attempt: attempt + 1,
+          maxRetries: this.config.maxRetries,
+          delayMs: Math.round(delay),
+          tool: toolCall.name,
+          error: error instanceof Error ? error.message : String(error),
+          turnId,
+        });
+
+        await sleep(delay);
+      }
+    }
+
+    return {
+      output: `Tool execution failed after ${this.config.maxRetries} retries: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+      is_error: true,
+      error_code: 500,
+    };
+  }
+
+  /**
+   * Cancel the current turn.
+   */
+  cancel(): void {
+    this.cancelled = true;
+    this.running = false;
+  }
+
+  /**
+   * Check if the loop is currently running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Get the current turn state.
+   */
+  getTurnState(): TurnState | null {
+    return this.currentTurn;
+  }
+
+  /**
+   * Get the context manager.
+   */
+  getContext(): AgentLoopContext | null {
+    return this.context;
+  }
+
+  /**
+   * Get the tool registry.
+   */
+  getToolRegistry(): ToolRegistry {
+    return this.toolRegistry;
+  }
+
+  /**
+   * Emit an NDJSON event (to stdout if streaming is enabled).
+   */
+  private emit(type: AgentEventType, data: Record<string, unknown>): void {
+    const event = makeEvent(type, data, this.currentTurn?.turnId);
+    if (this.config.streamNDJSON) {
+      emitNDJSON(event);
+    }
+  }
+
+  /**
+   * Build the final result object.
+   */
+  private buildResult(
+    turnId: string,
+    finalContent: string,
+    toolCallsExecuted: number,
+    totalTokens: TokenUsage,
+    error?: string,
+  ): AgentLoopResult {
+    return {
+      turnId,
+      finalContent,
+      toolCallsExecuted,
+      totalTokens,
+      iterations: this.currentTurn?.iterationCount || 0,
+      durationMs: this.currentTurn ? Date.now() - this.currentTurn.startTime : 0,
+      error,
+    };
+  }
+}
+
+/**
+ * Create a new AgentLoop instance.
+ */
+export function createAgentLoop(
+  llmCaller: LLMCaller,
+  toolRegistry: ToolRegistry,
+  config?: Partial<AgentLoopConfig>,
+): AgentLoop {
+  return new AgentLoop(llmCaller, toolRegistry, config);
+}

--- a/packages/opensin-sdk/src/agent_loop/context.ts
+++ b/packages/opensin-sdk/src/agent_loop/context.ts
@@ -1,0 +1,199 @@
+/**
+ * OpenSIN Agent Loop — Context Window Management
+ *
+ * Wraps the existing context management system for use in the agent loop.
+ * Handles automatic compression when the context window approaches its limit.
+ */
+
+import type { Message, ToolCall, ToolResult, TokenUsage, AssistantMessage, UserMessage, ToolResultMessage } from '../types.js';
+import type { AgentLoopConfig } from './types.js';
+import { OpenSINContextManager } from '../context_mgmt/manager.js';
+import { OpenSINContextCompressor } from '../context_mgmt/compressor.js';
+
+/**
+ * Estimate token count for a message.
+ * Uses a simple character-based heuristic (~4 chars per token).
+ */
+export function estimateMessageTokens(message: Message): number {
+  const content = typeof message.content === 'string'
+    ? message.content
+    : JSON.stringify(message.content);
+  return Math.ceil(content.length / 4);
+}
+
+/**
+ * Estimate total tokens for a message array.
+ */
+export function estimateTotalTokens(messages: Message[]): number {
+  return messages.reduce((sum, m) => sum + estimateMessageTokens(m), 0);
+}
+
+/**
+ * Context manager for the agent loop.
+ * Wraps OpenSINContextManager with agent-loop-specific logic.
+ */
+export class AgentLoopContext {
+  private manager: OpenSINContextManager;
+  private compressor: OpenSINContextCompressor;
+  private config: AgentLoopConfig;
+  private messages: Message[] = [];
+
+  constructor(sessionId: string, config: AgentLoopConfig) {
+    this.config = config;
+    this.manager = new OpenSINContextManager(sessionId, {
+      maxTokens: config.maxContextTokens,
+      compressionThreshold: config.compressionThreshold,
+      autoCompress: true,
+    });
+    this.compressor = new OpenSINContextCompressor();
+  }
+
+  /**
+   * Add a message to the context.
+   */
+  addMessage(message: Message): void {
+    this.messages.push(message);
+    const tokens = estimateMessageTokens(message);
+    const content = typeof message.content === 'string' ? message.content : JSON.stringify(message.content);
+    this.manager.addEntry(message.role as 'user' | 'assistant' | 'tool' | 'system', content, undefined, this.defaultPriority(message.role));
+
+    // Auto-compress if needed
+    if (this.manager.needsCompression()) {
+      this.compress();
+    }
+  }
+
+  /**
+   * Add a system message (highest priority, always preserved).
+   * System messages are stored as assistant messages with a system prefix
+   * since the Message type union doesn't include a system role directly.
+   */
+  addSystemMessage(content: string): void {
+    // Store as a special assistant message that acts as system prompt
+    const message: AssistantMessage = { role: 'assistant', content: `[SYSTEM] ${content}` };
+    this.messages.unshift(message);
+    this.manager.addEntry('system', content, undefined, 100);
+  }
+
+  /**
+   * Get the current messages array for sending to the LLM.
+   */
+  getMessages(): Message[] {
+    return [...this.messages];
+  }
+
+  /**
+   * Get the current token utilization (0.0–1.0).
+   */
+  getUtilization(): number {
+    return this.manager.getUtilization();
+  }
+
+  /**
+   * Get the total estimated token count.
+   */
+  getTotalTokens(): number {
+    return estimateTotalTokens(this.messages);
+  }
+
+  /**
+   * Check if compression is needed.
+   */
+  needsCompression(): boolean {
+    return this.manager.needsCompression();
+  }
+
+  /**
+   * Compress the context window.
+   * Returns the number of tokens saved.
+   */
+  compress(): number {
+    const before = this.getTotalTokens();
+
+    // Separate system messages (those starting with [SYSTEM])
+    const systemMessages = this.messages.filter(m =>
+      typeof m.content === 'string' && m.content.startsWith('[SYSTEM]')
+    );
+    const recentMessages = this.messages.slice(-Math.min(10, this.messages.length));
+    const middleMessages = this.messages.filter(
+      m => !(typeof m.content === 'string' && m.content.startsWith('[SYSTEM]')) && !recentMessages.includes(m)
+    );
+
+    // Summarize middle messages
+    const compressed: Message[] = [
+      ...systemMessages,
+      ...middleMessages.map(m => {
+        const tokens = estimateMessageTokens(m);
+        return {
+          role: m.role,
+          content: `[Previous ${m.role} message — ${tokens} tokens]`,
+        } as AssistantMessage;
+      }),
+      ...recentMessages,
+    ];
+
+    this.messages = compressed;
+
+    // Rebuild context manager state
+    this.manager = new OpenSINContextManager(this.manager.state.sessionId, {
+      maxTokens: this.config.maxContextTokens,
+      compressionThreshold: this.config.compressionThreshold,
+      autoCompress: true,
+    });
+
+    for (const msg of this.messages) {
+      const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+      this.manager.addEntry(
+        msg.role as 'user' | 'assistant' | 'tool' | 'system',
+        content,
+        undefined,
+        this.defaultPriority(msg.role)
+      );
+    }
+
+    const after = this.getTotalTokens();
+    return before - after;
+  }
+
+  /**
+   * Clear all messages except system messages.
+   */
+  clearConversation(): void {
+    this.messages = this.messages.filter(m =>
+      typeof m.content === 'string' && m.content.startsWith('[SYSTEM]')
+    );
+    this.manager.clear();
+    // Re-add system messages
+    for (const msg of this.messages) {
+      const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+      this.manager.addEntry('system', content, undefined, 100);
+    }
+  }
+
+  /**
+   * Get context stats.
+   */
+  getStats(): {
+    messageCount: number;
+    totalTokens: number;
+    utilization: number;
+    needsCompression: boolean;
+  } {
+    return {
+      messageCount: this.messages.length,
+      totalTokens: this.getTotalTokens(),
+      utilization: this.getUtilization(),
+      needsCompression: this.needsCompression(),
+    };
+  }
+
+  private defaultPriority(role: string): number {
+    if (role === 'system' || (typeof role === 'string' && role.includes('SYSTEM'))) return 100;
+    switch (role) {
+      case 'user': return 80;
+      case 'assistant': return 60;
+      case 'tool': return 40;
+      default: return 50;
+    }
+  }
+}

--- a/packages/opensin-sdk/src/agent_loop/index.ts
+++ b/packages/opensin-sdk/src/agent_loop/index.ts
@@ -1,0 +1,32 @@
+/**
+ * OpenSIN Agent Loop — Public API
+ *
+ * Core agent loop: Query input → API call → Tool execution → Response loop.
+ */
+
+export { AgentLoop, createAgentLoop } from './agent_loop.js';
+export { AgentLoopContext, estimateMessageTokens, estimateTotalTokens } from './context.js';
+export { ToolRegistry, createToolRegistry, type ToolHandler } from './tool_registry.js';
+export {
+  toNDJSONLine,
+  emitNDJSON,
+  makeEvent,
+  parseNDJSONLine,
+  parseNDJSONStream,
+  streamNDJSON,
+} from './ndjson.js';
+
+export type {
+  AgentEvent,
+  AgentEventType,
+  NDJSONLine,
+  AgentLoopConfig,
+  TurnState,
+  ToolExecutor,
+  LLMResponse,
+  LLMCaller,
+  LLMStreamCallback,
+  AgentLoopResult,
+} from './types.js';
+
+export { DEFAULT_AGENT_LOOP_CONFIG } from './types.js';

--- a/packages/opensin-sdk/src/agent_loop/ndjson.ts
+++ b/packages/opensin-sdk/src/agent_loop/ndjson.ts
@@ -1,0 +1,114 @@
+/**
+ * OpenSIN Agent Loop — NDJSON Streaming
+ *
+ * Handles Newline-Delimited JSON output for the agent loop.
+ * Each line is a valid JSON object representing an agent event.
+ */
+
+import type { AgentEvent, AgentEventType, NDJSONLine } from './types.js';
+
+/**
+ * Convert an AgentEvent to an NDJSON-compatible line.
+ */
+export function toNDJSONLine(event: AgentEvent): string {
+  const line: NDJSONLine = {
+    type: event.type,
+    ts: event.timestamp,
+    ...event.data,
+  };
+  if (event.turnId) {
+    line.turn = event.turnId;
+  }
+  return JSON.stringify(line);
+}
+
+/**
+ * Emit an NDJSON line to stdout.
+ */
+export function emitNDJSON(event: AgentEvent): void {
+  const line = toNDJSONLine(event);
+  process.stdout.write(line + '\n');
+}
+
+/**
+ * Create a typed AgentEvent with timestamp.
+ */
+export function makeEvent(
+  type: AgentEventType,
+  data: Record<string, unknown>,
+  turnId?: string,
+): AgentEvent {
+  return {
+    type,
+    timestamp: new Date().toISOString(),
+    turnId,
+    data,
+  };
+}
+
+/**
+ * Parse a single NDJSON line into an AgentEvent.
+ * Returns null if the line is not valid JSON.
+ */
+export function parseNDJSONLine(line: string): AgentEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed) as NDJSONLine;
+    const { type, ts, turn, ...data } = parsed;
+    return {
+      type: type as AgentEventType,
+      timestamp: ts || new Date().toISOString(),
+      turnId: turn,
+      data,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a stream of NDJSON lines from a string.
+ */
+export function parseNDJSONStream(text: string): AgentEvent[] {
+  const events: AgentEvent[] = [];
+  for (const line of text.split('\n')) {
+    const event = parseNDJSONLine(line);
+    if (event) {
+      events.push(event);
+    }
+  }
+  return events;
+}
+
+/**
+ * Create an async generator that yields parsed NDJSON events from a ReadableStream.
+ */
+export async function* streamNDJSON(
+  stream: AsyncIterable<string>,
+): AsyncGenerator<AgentEvent, void, unknown> {
+  let buffer = '';
+
+  for await (const chunk of stream) {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    // Keep the last (potentially incomplete) line in the buffer
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const event = parseNDJSONLine(line);
+      if (event) {
+        yield event;
+      }
+    }
+  }
+
+  // Flush remaining buffer
+  if (buffer.trim()) {
+    const event = parseNDJSONLine(buffer);
+    if (event) {
+      yield event;
+    }
+  }
+}

--- a/packages/opensin-sdk/src/agent_loop/tool_registry.ts
+++ b/packages/opensin-sdk/src/agent_loop/tool_registry.ts
@@ -1,0 +1,103 @@
+/**
+ * OpenSIN Agent Loop — Tool Registry
+ *
+ * Registry for available tools with execution dispatch.
+ */
+
+import type { ToolDefinition, ToolCall, ToolResult } from '../types.js';
+import type { ToolExecutor } from './types.js';
+
+export interface ToolHandler {
+  definition: ToolDefinition;
+  execute: ToolExecutor;
+}
+
+export class ToolRegistry {
+  private tools: Map<string, ToolHandler> = new Map();
+
+  /**
+   * Register a tool with its handler.
+   */
+  register(name: string, handler: ToolHandler): void {
+    this.tools.set(name, handler);
+  }
+
+  /**
+   * Unregister a tool.
+   */
+  unregister(name: string): boolean {
+    return this.tools.delete(name);
+  }
+
+  /**
+   * Get a tool handler by name.
+   */
+  get(name: string): ToolHandler | undefined {
+    return this.tools.get(name);
+  }
+
+  /**
+   * Get all tool definitions (for sending to LLM).
+   */
+  getDefinitions(): ToolDefinition[] {
+    return Array.from(this.tools.values()).map(h => h.definition);
+  }
+
+  /**
+   * Get all registered tool names.
+   */
+  getNames(): string[] {
+    return Array.from(this.tools.keys());
+  }
+
+  /**
+   * Execute a tool call.
+   */
+  async execute(
+    toolCall: ToolCall,
+    workspace: string,
+    sessionId: string,
+  ): Promise<ToolResult> {
+    const handler = this.tools.get(toolCall.name);
+    if (!handler) {
+      return {
+        output: `Error: Unknown tool "${toolCall.name}"`,
+        is_error: true,
+        error_code: 404,
+        metadata: { tool_name: toolCall.name },
+      };
+    }
+
+    try {
+      return await handler.execute(toolCall, workspace, sessionId);
+    } catch (error) {
+      return {
+        output: `Error executing tool "${toolCall.name}": ${error instanceof Error ? error.message : String(error)}`,
+        is_error: true,
+        error_code: 500,
+        metadata: { tool_name: toolCall.name },
+      };
+    }
+  }
+
+  /**
+   * Check if a tool is registered.
+   */
+  has(name: string): boolean {
+    return this.tools.has(name);
+  }
+
+  /**
+   * Get the count of registered tools.
+   */
+  get size(): number {
+    return this.tools.size;
+  }
+}
+
+/**
+ * Create a new ToolRegistry instance.
+ */
+export function createToolRegistry(): ToolRegistry {
+  return new ToolRegistry();
+}

--- a/packages/opensin-sdk/src/agent_loop/types.ts
+++ b/packages/opensin-sdk/src/agent_loop/types.ts
@@ -1,0 +1,130 @@
+/**
+ * OpenSIN Agent Loop — Type Definitions
+ *
+ * Core types for the agent loop: query → API → tools → repeat.
+ * NDJSON streaming, error handling, retry logic, context management.
+ */
+
+import type { Message, ToolCall, ToolResult, ToolDefinition, TokenUsage, StreamChunk } from '../types.js';
+
+// --- Agent Loop Events (NDJSON output) ---
+
+export type AgentEventType =
+  | 'status'
+  | 'thinking'
+  | 'text_delta'
+  | 'tool_call_start'
+  | 'tool_call_end'
+  | 'tool_result'
+  | 'error'
+  | 'retry'
+  | 'context_compressed'
+  | 'turn_complete'
+  | 'session_start'
+  | 'session_end';
+
+export interface AgentEvent {
+  type: AgentEventType;
+  timestamp: string;
+  turnId?: string;
+  data: Record<string, unknown>;
+}
+
+// --- NDJSON Line ---
+
+export interface NDJSONLine {
+  type: AgentEventType;
+  ts: string;
+  turn?: string;
+  [key: string]: unknown;
+}
+
+// --- Agent Loop Configuration ---
+
+export interface AgentLoopConfig {
+  /** Maximum number of tool-execution iterations per turn */
+  maxToolIterations: number;
+  /** Maximum retries on transient errors */
+  maxRetries: number;
+  /** Base delay in ms for exponential backoff */
+  retryBaseDelayMs: number;
+  /** Maximum delay in ms for exponential backoff */
+  retryMaxDelayMs: number;
+  /** Context window max tokens */
+  maxContextTokens: number;
+  /** Compression threshold (0.0–1.0) */
+  compressionThreshold: number;
+  /** Whether to stream NDJSON to stdout */
+  streamNDJSON: boolean;
+  /** Model identifier */
+  model: string;
+  /** Workspace directory */
+  workspace: string;
+  /** Permission mode for tool execution */
+  permissionMode: 'auto' | 'ask' | 'readonly';
+}
+
+export const DEFAULT_AGENT_LOOP_CONFIG: AgentLoopConfig = {
+  maxToolIterations: 50,
+  maxRetries: 3,
+  retryBaseDelayMs: 1000,
+  retryMaxDelayMs: 10000,
+  maxContextTokens: 128000,
+  compressionThreshold: 0.8,
+  streamNDJSON: true,
+  model: 'openai/gpt-5.4',
+  workspace: process.cwd(),
+  permissionMode: 'auto',
+};
+
+// --- Turn State ---
+
+export interface TurnState {
+  turnId: string;
+  messages: Message[];
+  toolCalls: ToolCall[];
+  toolResults: ToolResult[];
+  iterationCount: number;
+  retryCount: number;
+  totalTokens: number;
+  startTime: number;
+  status: 'running' | 'completed' | 'error' | 'cancelled';
+  error?: string;
+}
+
+// --- Tool Executor ---
+
+export type ToolExecutor = (
+  toolCall: ToolCall,
+  workspace: string,
+  sessionId: string,
+) => Promise<ToolResult>;
+
+// --- LLM Caller (wraps opencode CLI or provider) ---
+
+export interface LLMResponse {
+  content: string;
+  toolCalls: ToolCall[];
+  usage: TokenUsage;
+  stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'error';
+}
+
+export type LLMCaller = (
+  messages: Message[],
+  tools: ToolDefinition[],
+  options?: { stream?: boolean; max_tokens?: number; temperature?: number },
+) => Promise<LLMResponse>;
+
+export type LLMStreamCallback = (chunk: StreamChunk) => void;
+
+// --- Agent Loop Result ---
+
+export interface AgentLoopResult {
+  turnId: string;
+  finalContent: string;
+  toolCallsExecuted: number;
+  totalTokens: TokenUsage;
+  iterations: number;
+  durationMs: number;
+  error?: string;
+}

--- a/packages/opensin-sdk/src/context_mgmt/compressor.ts
+++ b/packages/opensin-sdk/src/context_mgmt/compressor.ts
@@ -22,21 +22,21 @@ export class OpenSINContextCompressor {
 
     switch (strategy) {
       case 'truncate':
-        return this.truncate(entries, maxTokens, start)
+        return this.truncate(entries, maxTokens, start, originalTokens)
       case 'summarize':
-        return this.summarize(entries, maxTokens, start)
+        return this.summarize(entries, maxTokens, start, originalTokens)
       case 'sliding_window':
-        return this.slidingWindow(entries, maxTokens, start)
+        return this.slidingWindow(entries, maxTokens, start, originalTokens)
       case 'priority_based':
-        return this.priorityBased(entries, maxTokens, start)
+        return this.priorityBased(entries, maxTokens, start, originalTokens)
       case 'hybrid':
-        return this.hybrid(entries, maxTokens, start)
+        return this.hybrid(entries, maxTokens, start, originalTokens)
       default:
-        return this.priorityBased(entries, maxTokens, start)
+        return this.priorityBased(entries, maxTokens, start, originalTokens)
     }
   }
 
-  private truncate(entries: ContextEntry[], maxTokens: number, start: number): CompressionResult {
+  private truncate(entries: ContextEntry[], maxTokens: number, start: number, originalTokens: number): CompressionResult {
     let currentTokens = 0
     const kept: ContextEntry[] = []
     let removed = 0
@@ -64,7 +64,7 @@ export class OpenSINContextCompressor {
     }
   }
 
-  private summarize(entries: ContextEntry[], maxTokens: number, start: number): CompressionResult {
+  private summarize(entries: ContextEntry[], maxTokens: number, start: number, originalTokens: number): CompressionResult {
     const systemEntries = entries.filter((e) => e.role === 'system')
     const recentEntries = entries.slice(-Math.min(10, entries.length))
     const otherEntries = entries.filter(
@@ -105,7 +105,7 @@ export class OpenSINContextCompressor {
     }
   }
 
-  private slidingWindow(entries: ContextEntry[], maxTokens: number, start: number): CompressionResult {
+  private slidingWindow(entries: ContextEntry[], maxTokens: number, start: number, originalTokens: number): CompressionResult {
     const systemEntries = entries.filter((e) => e.role === 'system')
     const systemTokens = systemEntries.reduce((s, e) => s + e.tokenCount, 0)
     const availableTokens = maxTokens - systemTokens
@@ -138,7 +138,7 @@ export class OpenSINContextCompressor {
     }
   }
 
-  private priorityBased(entries: ContextEntry[], maxTokens: number, start: number): CompressionResult {
+  private priorityBased(entries: ContextEntry[], maxTokens: number, start: number, originalTokens: number): CompressionResult {
     const sorted = [...entries].sort((a, b) => b.priority - a.priority)
     const kept: ContextEntry[] = []
     let currentTokens = 0
@@ -167,7 +167,7 @@ export class OpenSINContextCompressor {
     }
   }
 
-  private hybrid(entries: ContextEntry[], maxTokens: number, start: number): CompressionResult {
+  private hybrid(entries: ContextEntry[], maxTokens: number, start: number, originalTokens: number): CompressionResult {
     const systemEntries = entries.filter((e) => e.role === 'system')
     const systemTokens = systemEntries.reduce((s, e) => s + e.tokenCount, 0)
     const availableTokens = maxTokens - systemTokens
@@ -176,7 +176,7 @@ export class OpenSINContextCompressor {
     const highTokens = highPriority.reduce((s, e) => s + e.tokenCount, 0)
 
     if (highTokens > availableTokens) {
-      return this.priorityBased(entries, maxTokens, start)
+      return this.priorityBased(entries, maxTokens, start, originalTokens)
     }
 
     const remainingTokens = availableTokens - highTokens


### PR DESCRIPTION
## Summary

- **Core Agent Loop**: Full implementation of the query → API call → tool execution → response cycle in `packages/opensin-sdk/src/agent_loop/`
- **NDJSON Streaming**: Every event (status, thinking, text_delta, tool_call_start/end, tool_result, error, retry, context_compressed, turn_complete, session_start/end) emitted as newline-delimited JSON to stdout
- **Error Recovery**: Exponential backoff with jitter for transient errors (rate limits, 429/502/503/504, timeouts, network errors); non-transient errors fail immediately without retry
- **Tool Result Processing**: Tool calls detected from LLM response, executed via `ToolRegistry`, results re-injected into context for next LLM turn — loop continues until no more tool calls
- **Context Window Management**: Auto-compression when utilization exceeds configurable threshold, system message preservation, priority-based message retention, conversation clearing
- **Bug Fix**: Fixed pre-existing bug in `context_mgmt/compressor.ts` where `originalTokens` was computed but never passed to sub-methods

## Architecture

```
src/agent_loop/
├── types.ts          # All type definitions (AgentEvent, AgentLoopConfig, TurnState, LLMResponse, etc.)
├── agent_loop.ts     # Core AgentLoop class — the main loop engine
├── context.ts        # AgentLoopContext — context window management with auto-compression
├── ndjson.ts         # NDJSON serialization/parsing/streaming utilities
├── tool_registry.ts  # ToolRegistry — tool registration and execution dispatch
└── index.ts          # Public API exports
```

## Acceptance Criteria

- [x] Core loop runs continuously (until no tool calls or max iterations)
- [x] Handles tool results correctly (re-injects into context, continues loop)
- [x] Streams NDJSON output (all event types verified in tests)
- [x] Error recovery works (exponential backoff retry, non-transient fail-fast)
- [x] Tests pass (33 new tests, 334 total — all green)
- [x] Code reviewed (self-review complete)
- [x] Documentation updated (JSDoc on all public APIs)

## Test Results

```
Test Files  10 passed (10)
Tests       334 passed (334)
```

33 new tests covering:
- NDJSON serialization/parsing/streaming (6 tests)
- Tool registry CRUD and execution (5 tests)
- Context window management (6 tests)
- Core agent loop (5 tests)
- Error recovery & retry logic (4 tests)
- NDJSON streaming integration (3 tests)
- Async NDJSON stream parsing (2 tests)
- Turn state tracking (2 tests)