### PR TITLE
feat: add orchestrator and autonomous runtime layers

### DIFF
--- a/packages/opensin-sdk/src/__tests__/approval.test.ts
+++ b/packages/opensin-sdk/src/__tests__/approval.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { ApprovalHooks, createApprovalHooks, DEFAULT_RULES } from '../approval/index'
+import type { ApprovalEvent, ApprovalRule, ApprovalRequest } from '../approval/index'
+
+describe('ApprovalHooks', () => {
+  let hooks: ApprovalHooks
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    hooks = createApprovalHooks()
+  })
+
+  afterEach(() => {
+    hooks.destroy()
+    vi.useRealTimers()
+  })
+
+  it('should auto-approve safe operations', async () => {
+    const result = await hooks.evaluateAction('read_file', { path: '/test.txt' })
+    expect(result.approved).toBe(true)
+    expect(result.riskLevel).toBe('auto')
+  })
+
+  it('should auto-approve search/list operations', async () => {
+    const result = await hooks.evaluateAction('grep', { pattern: 'test' })
+    expect(result.approved).toBe(true)
+    expect(result.riskLevel).toBe('auto')
+  })
+
+  it('should notify on write operations', async () => {
+    const result = await hooks.evaluateAction('write_file', { path: '/test.txt', content: 'hello' })
+    expect(result.approved).toBe(true)
+    expect(result.riskLevel).toBe('notify')
+    expect(result.requestId).toBeTruthy()
+  })
+
+  it('should require approval for destructive operations', async () => {
+    const result = await hooks.evaluateAction('delete_file', { path: '/test.txt' })
+    expect(result.approved).toBe(false)
+    expect(result.riskLevel).toBe('approve')
+    expect(result.requestId).toBeTruthy()
+  })
+
+  it('should require approval for network operations', async () => {
+    const result = await hooks.evaluateAction('deploy_production', { env: 'prod' })
+    expect(result.approved).toBe(false)
+    expect(result.riskLevel).toBe('approve')
+  })
+
+  it('should require approval for financial operations', async () => {
+    const result = await hooks.evaluateAction('payment_charge', { amount: 100 })
+    expect(result.approved).toBe(false)
+    expect(result.riskLevel).toBe('approve')
+  })
+
+  it('should require approval for auth operations', async () => {
+    const result = await hooks.evaluateAction('token_rotate', { service: 'aws' })
+    expect(result.approved).toBe(false)
+    expect(result.riskLevel).toBe('approve')
+  })
+
+  it('should auto-approve unknown actions', async () => {
+    const result = await hooks.evaluateAction('custom_unknown_action', {})
+    expect(result.approved).toBe(true)
+    expect(result.riskLevel).toBe('auto')
+  })
+
+  it('should resolve approval requests', async () => {
+    await hooks.evaluateAction('delete_file', { path: '/test.txt' })
+    const pending = hooks.getPendingRequests()
+    expect(pending.length).toBe(1)
+
+    const resolved = hooks.resolveRequest({
+      requestId: pending[0].id,
+      decision: 'approve',
+      resolvedBy: 'admin',
+      reason: 'Confirmed safe',
+    })
+
+    expect(resolved).not.toBeNull()
+    expect(resolved!.status).toBe('approved')
+    expect(resolved!.resolvedBy).toBe('admin')
+  })
+
+  it('should reject approval requests', async () => {
+    await hooks.evaluateAction('delete_file', { path: '/test.txt' })
+    const pending = hooks.getPendingRequests()
+
+    const resolved = hooks.resolveRequest({
+      requestId: pending[0].id,
+      decision: 'reject',
+      resolvedBy: 'admin',
+      reason: 'Too risky',
+    })
+
+    expect(resolved!.status).toBe('rejected')
+  })
+
+  it('should track audit log', async () => {
+    await hooks.evaluateAction('delete_file', { path: '/test.txt' })
+    const pending = hooks.getPendingRequests()
+
+    hooks.resolveRequest({
+      requestId: pending[0].id,
+      decision: 'approve',
+      resolvedBy: 'admin',
+    })
+
+    const log = hooks.getAuditLog()
+    expect(log.length).toBe(1)
+    expect(log[0].status).toBe('approved')
+  })
+
+  it('should send notifications via channel', async () => {
+    const notifications: ApprovalRequest[] = []
+    hooks.setNotificationChannel(async (req) => {
+      notifications.push(req)
+    })
+
+    await hooks.evaluateAction('deploy_production', { env: 'prod' })
+    expect(notifications.length).toBe(1)
+    expect(notifications[0].action).toBe('deploy_production')
+  })
+
+  it('should add custom rules', async () => {
+    hooks.addRule({
+      id: 'custom-block',
+      name: 'Block test actions',
+      actionPatterns: ['test_block_*'],
+      riskLevel: 'approve',
+      conditions: [],
+      timeoutMs: 60000,
+      timeoutAction: 'reject',
+      enabled: true,
+      metadata: {},
+    })
+
+    const result = await hooks.evaluateAction('test_block_action', {})
+    expect(result.approved).toBe(false)
+    expect(result.riskLevel).toBe('approve')
+  })
+
+  it('should remove rules', () => {
+    expect(hooks.removeRule('auto-safe-ops')).toBe(true)
+    expect(hooks.removeRule('nonexistent')).toBe(false)
+  })
+
+  it('should update rules', () => {
+    const updated = hooks.updateRule('auto-safe-ops', { enabled: false })
+    expect(updated?.enabled).toBe(false)
+  })
+
+  it('should list rules', () => {
+    const all = hooks.listRules()
+    expect(all.length).toBe(DEFAULT_RULES.length)
+
+    const enabled = hooks.listRules(true)
+    expect(enabled.length).toBe(DEFAULT_RULES.length)
+  })
+
+  it('should emit events', async () => {
+    const events: ApprovalEvent[] = []
+    hooks.onEvent(e => events.push(e))
+
+    await hooks.evaluateAction('delete_file', { path: '/test.txt' })
+    const created = events.find(e => e.type === 'request_created')
+    expect(created).toBeDefined()
+  })
+
+  it('should allow unsubscribing from events', async () => {
+    const events: ApprovalEvent[] = []
+    const unsub = hooks.onEvent(e => events.push(e))
+
+    await hooks.evaluateAction('delete_file', { path: '/test.txt' })
+    unsub()
+    await hooks.evaluateAction('delete_file', { path: '/test2.txt' })
+
+    expect(events.length).toBe(1)
+  })
+
+  it('should expire pending requests', () => {
+    hooks.createTask && null
+
+    const request: ApprovalRequest = {
+      id: 'test-1',
+      ruleId: 'approve-destructive-ops',
+      action: 'delete_file',
+      input: {},
+      riskLevel: 'approve',
+      status: 'pending',
+      requestedAt: new Date(Date.now() - 700000).toISOString(),
+      resolvedAt: null,
+      resolvedBy: null,
+      timeoutMs: 600000,
+      expiresAt: new Date(Date.now() - 100000).toISOString(),
+    }
+
+    const pending = hooks.getPendingRequests()
+    expect(pending.length).toBe(0)
+  })
+})
+
+describe('DEFAULT_RULES', () => {
+  it('should have 6 default rules', () => {
+    expect(DEFAULT_RULES.length).toBe(6)
+  })
+
+  it('should have unique ids', () => {
+    const ids = DEFAULT_RULES.map(r => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('should cover all risk levels', () => {
+    const levels = new Set(DEFAULT_RULES.map(r => r.riskLevel))
+    expect(levels.has('auto')).toBe(true)
+    expect(levels.has('notify')).toBe(true)
+    expect(levels.has('approve')).toBe(true)
+  })
+})
+
+describe('createApprovalHooks', () => {
+  it('should create with default rules', () => {
+    const hooks = createApprovalHooks()
+    expect(hooks.listRules().length).toBe(DEFAULT_RULES.length)
+    hooks.destroy()
+  })
+
+  it('should create with custom rules', () => {
+    const custom: ApprovalRule[] = [{
+      id: 'test-only',
+      name: 'Test Rule',
+      actionPatterns: ['*'],
+      riskLevel: 'auto',
+      conditions: [],
+      timeoutMs: 0,
+      timeoutAction: 'approve',
+      enabled: true,
+      metadata: {},
+    }]
+    const hooks = createApprovalHooks(custom)
+    expect(hooks.listRules().length).toBe(1)
+    hooks.destroy()
+  })
+})

--- a/packages/opensin-sdk/src/__tests__/cli_agent_orchestrator.test.ts
+++ b/packages/opensin-sdk/src/__tests__/cli_agent_orchestrator.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { CLIAgent } from '../cli-agent/index'
+
+describe('CLIAgent orchestrator integration', () => {
+  it('should expose an orchestrator and route model selection during command processing', async () => {
+    const agent = new CLIAgent({
+      sessionId: 'session-1',
+      model: 'openai/gpt-4o-mini',
+      provider: 'openai',
+      workspacePath: '/tmp',
+      maxTokens: 4096,
+      temperature: 0,
+      interactive: false,
+      batchMode: true,
+      contextWindowSize: 8192,
+      toolTimeoutMs: 5000,
+      autoApproveTools: [],
+      verbose: false,
+    })
+
+    expect(agent.getOrchestrator()).toBeDefined()
+
+    await agent.processCommand({
+      type: 'chat',
+      input: 'Hello there',
+    })
+
+    expect(agent.getState().config.model).toBe('google/antigravity-gemini-3-flash')
+    expect(agent.getState().config.provider).toBe('antigravity')
+  })
+})

--- a/packages/opensin-sdk/src/__tests__/cron.test.ts
+++ b/packages/opensin-sdk/src/__tests__/cron.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { CronScheduler, createCronScheduler, parseCronExpression, getNextExecution } from '../cron/index'
+import type { CronEvent, CronTask } from '../cron/index'
+
+describe('parseCronExpression', () => {
+  it('should parse every-minute expression', () => {
+    const result = parseCronExpression('* * * * *')
+    expect(result).not.toBeNull()
+    expect(result!.minute.length).toBe(60)
+    expect(result!.hour.length).toBe(24)
+  })
+
+  it('should parse specific minute', () => {
+    const result = parseCronExpression('30 * * * *')
+    expect(result).not.toBeNull()
+    expect(result!.minute).toEqual([30])
+  })
+
+  it('should parse range expression', () => {
+    const result = parseCronExpression('1-5 * * * *')
+    expect(result).not.toBeNull()
+    expect(result!.minute).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('should parse step expression', () => {
+    const result = parseCronExpression('*/15 * * * *')
+    expect(result).not.toBeNull()
+    expect(result!.minute).toEqual([0, 15, 30, 45])
+  })
+
+  it('should parse full daily cron', () => {
+    const result = parseCronExpression('0 9 * * *')
+    expect(result).not.toBeNull()
+    expect(result!.minute).toEqual([0])
+    expect(result!.hour).toEqual([9])
+  })
+
+  it('should parse day-of-week', () => {
+    const result = parseCronExpression('0 9 * * 1')
+    expect(result).not.toBeNull()
+    expect(result!.dayOfWeek).toEqual([1])
+  })
+
+  it('should return null for invalid expressions', () => {
+    expect(parseCronExpression('')).toBeNull()
+    expect(parseCronExpression('too many fields here')).toBeNull()
+    expect(parseCronExpression('a b c d e')).toBeNull()
+    expect(parseCronExpression('60 * * * *')).toBeNull()
+  })
+
+  it('should parse comma-separated values', () => {
+    const result = parseCronExpression('0,15,30,45 * * * *')
+    expect(result).not.toBeNull()
+    expect(result!.minute).toEqual([0, 15, 30, 45])
+  })
+})
+
+describe('getNextExecution', () => {
+  it('should find next minute for * * * * *', () => {
+    const parsed = parseCronExpression('* * * * *')
+    const now = new Date('2026-01-01T12:00:00Z')
+    const next = getNextExecution(parsed, now)
+    expect(next).not.toBeNull()
+    expect(next!.getTime()).toBeGreaterThan(now.getTime())
+  })
+
+  it('should find next 9am for 0 9 * * *', () => {
+    const parsed = parseCronExpression('0 9 * * *')
+    const now = new Date('2026-01-01T08:00:00Z')
+    const next = getNextExecution(parsed, now)
+    expect(next).not.toBeNull()
+    expect(next!.getHours()).toBe(9)
+    expect(next!.getMinutes()).toBe(0)
+  })
+
+  it('should return null for invalid parsed input', () => {
+    expect(getNextExecution(null)).toBeNull()
+  })
+
+  it('should skip to next day if time has passed', () => {
+    const parsed = parseCronExpression('0 9 * * *')
+    const now = new Date('2026-01-01T10:00:00Z')
+    const next = getNextExecution(parsed, now)
+    expect(next).not.toBeNull()
+    expect(next!.getDate()).toBeGreaterThan(now.getDate())
+  })
+})
+
+describe('CronScheduler', () => {
+  let scheduler: CronScheduler
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    scheduler = createCronScheduler(undefined, 1000)
+  })
+
+  afterEach(() => {
+    scheduler.stop()
+    vi.useRealTimers()
+  })
+
+  it('should create a cron task', () => {
+    const task = scheduler.createTask({
+      name: 'Daily Summary',
+      cronExpression: '0 9 * * *',
+      prompt: 'Generate daily summary',
+      enabled: true,
+      timeoutMs: 60000,
+      retryOnFailure: false,
+      maxRetries: 0,
+      metadata: {},
+    })
+
+    expect(task.id).toBeTruthy()
+    expect(task.name).toBe('Daily Summary')
+    expect(task.cronExpression).toBe('0 9 * * *')
+    expect(task.enabled).toBe(true)
+    expect(task.executionCount).toBe(0)
+    expect(task.nextExecutionAt).not.toBeNull()
+  })
+
+  it('should reject invalid cron expressions', () => {
+    expect(() =>
+      scheduler.createTask({
+        name: 'Bad',
+        cronExpression: 'invalid',
+        prompt: 'test',
+        enabled: true,
+        timeoutMs: 60000,
+        retryOnFailure: false,
+        maxRetries: 0,
+        metadata: {},
+      })
+    ).toThrow('Invalid cron expression')
+  })
+
+  it('should list tasks', () => {
+    scheduler.createTask({
+      name: 'Task 1', cronExpression: '0 9 * * *', prompt: 'p1',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+    scheduler.createTask({
+      name: 'Task 2', cronExpression: '0 18 * * *', prompt: 'p2',
+      enabled: false, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    expect(scheduler.listTasks().length).toBe(2)
+    expect(scheduler.listTasks(true).length).toBe(1)
+  })
+
+  it('should get task by id', () => {
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '* * * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+    expect(scheduler.getTask(task.id)).toBeDefined()
+    expect(scheduler.getTask('nonexistent')).toBeUndefined()
+  })
+
+  it('should update tasks', () => {
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '0 9 * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    const updated = scheduler.updateTask(task.id, { name: 'Updated', enabled: false })
+    expect(updated?.name).toBe('Updated')
+    expect(updated?.enabled).toBe(false)
+  })
+
+  it('should delete tasks', () => {
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '* * * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+    expect(scheduler.deleteTask(task.id)).toBe(true)
+    expect(scheduler.getTask(task.id)).toBeUndefined()
+  })
+
+  it('should enable/disable tasks', () => {
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '* * * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    const disabled = scheduler.disableTask(task.id)
+    expect(disabled?.enabled).toBe(false)
+
+    const enabled = scheduler.enableTask(task.id)
+    expect(enabled?.enabled).toBe(true)
+  })
+
+  it('should execute tasks via executor', async () => {
+    const calls: string[] = []
+    const exec = scheduler as unknown as { executeTask(task: CronTask): Promise<void> }
+
+    scheduler.setExecutor(async (prompt) => {
+      calls.push(prompt)
+      return `Result: ${prompt}`
+    })
+
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '* * * * *', prompt: 'hello',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    await exec.executeTask(task)
+    expect(calls).toEqual(['hello'])
+    expect(task.executionCount).toBe(1)
+    expect(task.lastExecutedAt).not.toBeNull()
+  })
+
+  it('should emit events', () => {
+    const events: CronEvent[] = []
+    scheduler.onEvent(e => events.push(e))
+
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '0 9 * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    const created = events.find(e => e.type === 'task_created')
+    expect(created).toBeDefined()
+    expect(created!.taskId).toBe(task.id)
+  })
+
+  it('should track executions', async () => {
+    scheduler.setExecutor(async (prompt) => `result: ${prompt}`)
+
+    const exec = scheduler as unknown as { executeTask(task: CronTask): Promise<void> }
+
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '* * * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    await exec.executeTask(task)
+
+    const executions = scheduler.getExecutions(task.id)
+    expect(executions.length).toBe(1)
+    expect(executions[0].status).toBe('completed')
+    expect(executions[0].result).toContain('result')
+  })
+
+  it('should handle executor errors', async () => {
+    scheduler.setExecutor(async () => { throw new Error('boom') })
+    const exec = scheduler as unknown as { executeTask(task: CronTask): Promise<void> }
+
+    const task = scheduler.createTask({
+      name: 'Test', cronExpression: '* * * * *', prompt: 'p',
+      enabled: true, timeoutMs: 60000, retryOnFailure: false, maxRetries: 0, metadata: {},
+    })
+
+    await exec.executeTask(task)
+
+    const executions = scheduler.getExecutions(task.id)
+    expect(executions[0].status).toBe('failed')
+  })
+
+  it('should start and stop', () => {
+    expect(scheduler.isRunning()).toBe(false)
+    scheduler.start()
+    expect(scheduler.isRunning()).toBe(true)
+    scheduler.stop()
+    expect(scheduler.isRunning()).toBe(false)
+  })
+})

--- a/packages/opensin-sdk/src/__tests__/failover.test.ts
+++ b/packages/opensin-sdk/src/__tests__/failover.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { FailoverRouter, createFailoverRouter, OPENSIN_MODELS, DEFAULT_CHAINS } from '../model_routing/failover'
+import type { FailoverEvent, FailoverChain } from '../model_routing/failover'
+
+describe('FailoverRouter', () => {
+  let router: FailoverRouter
+
+  beforeEach(() => {
+    router = createFailoverRouter()
+  })
+
+  it('should route to first available model in default chain', () => {
+    const result = router.route('Hello world')
+    expect(result.selectedModel).toBeDefined()
+    expect(result.selectedModel.id).toBe('openai/gpt-5.4')
+    expect(result.chainId).toBe('default')
+    expect(result.attempt).toBe(1)
+  })
+
+  it('should use fast chain when preferSpeed is set', () => {
+    const result = router.route('Quick task', { preferSpeed: true })
+    expect(result.selectedModel.id).toBe('google/antigravity-gemini-3-flash')
+  })
+
+  it('should use reasoning chain for reasoning tasks', () => {
+    const result = router.route('Analyze this', { requiresReasoning: true })
+    expect(result.selectedModel.id).toBe('google/antigravity-claude-opus-4-6-thinking')
+  })
+
+  it('should use long-context chain for long context tasks', () => {
+    const result = router.route('Long doc', { requiresLongContext: true })
+    expect(result.selectedModel.id).toBe('google/antigravity-gemini-3.1-pro')
+  })
+
+  it('should skip models on cooldown after failure', () => {
+    router.reportFailure('openai/gpt-5.4', 'rate_limit')
+    const result = router.route('Hello world')
+    expect(result.selectedModel.id).not.toBe('openai/gpt-5.4')
+  })
+
+  it('should get fallback model', () => {
+    const fallback = router.getFallback('openai/gpt-5.4', 'default', 'error')
+    expect(fallback).not.toBeNull()
+    expect(fallback!.selectedModel.id).toBe('google/antigravity-claude-sonnet-4-6')
+    expect(fallback!.fallbackFrom).toBe('openai/gpt-5.4')
+  })
+
+  it('should return null when chain is exhausted', () => {
+    const chain = router.getChain('default')!
+    const lastModel = chain.models[chain.models.length - 1]
+    const fallback = router.getFallback(lastModel.id, 'default', 'error')
+    expect(fallback).toBeNull()
+  })
+
+  it('should report success and reduce failure count', () => {
+    router.reportFailure('openai/gpt-5.4', 'error1')
+    const health1 = router.getModelHealth('openai/gpt-5.4')
+    expect(health1!.failures).toBe(1)
+
+    router.reportSuccess('openai/gpt-5.4')
+    const health2 = router.getModelHealth('openai/gpt-5.4')
+    expect(health2!.failures).toBe(0)
+    expect(health2!.cooldownUntil).toBeNull()
+  })
+
+  it('should list chains', () => {
+    const chains = router.listChains()
+    expect(chains.length).toBe(4)
+  })
+
+  it('should get chain by id', () => {
+    const chain = router.getChain('default')
+    expect(chain).toBeDefined()
+    expect(chain!.name).toBe('Default Chain')
+  })
+
+  it('should set active chain', () => {
+    router.setActiveChain('fast')
+    const result = router.route('Hello')
+    expect(result.chainId).toBe('fast')
+  })
+
+  it('should add custom chain', () => {
+    const customChain: FailoverChain = {
+      id: 'custom',
+      name: 'Custom Chain',
+      models: [OPENSIN_MODELS[0]],
+      strategy: 'cost-first',
+    }
+    router.addChain(customChain)
+    expect(router.getChain('custom')).toBeDefined()
+  })
+
+  it('should track recent routes', () => {
+    router.route('Task 1')
+    router.route('Task 2')
+    const recent = router.getRecentRoutes(5)
+    expect(recent.length).toBe(2)
+  })
+
+  it('should emit fallback events', () => {
+    const events: FailoverEvent[] = []
+    router.onEvent(e => events.push(e))
+
+    router.reportFailure('openai/gpt-5.4', 'test_error')
+
+    const fallback = events.find(e => e.type === 'fallback')
+    expect(fallback).toBeDefined()
+    expect(fallback!.modelId).toBe('openai/gpt-5.4')
+  })
+
+  it('should skip models without vision capability when required', () => {
+    const result = router.route('Analyze image', { requiresVision: true })
+    expect(result.selectedModel.capabilities).toContain('vision')
+  })
+
+  it('should estimate latency based on profile', () => {
+    const result = router.route('Hello')
+    expect(result.estimatedLatencyMs).toBeGreaterThan(0)
+  })
+
+  it('should allow unsubscribing from events', () => {
+    const events: FailoverEvent[] = []
+    const unsub = router.onEvent(e => events.push(e))
+
+    router.route('test1')
+    unsub()
+    router.route('test2')
+
+    expect(events.length).toBe(1)
+  })
+})
+
+describe('OPENSIN_MODELS', () => {
+  it('should contain all expected models', () => {
+    const ids = OPENSIN_MODELS.map(m => m.id)
+    expect(ids).toContain('openai/gpt-5.4')
+    expect(ids).toContain('google/antigravity-claude-sonnet-4-6')
+    expect(ids).toContain('google/antigravity-gemini-3.1-pro')
+    expect(ids).toContain('google/antigravity-claude-opus-4-6-thinking')
+    expect(ids).toContain('google/antigravity-gemini-3-flash')
+    expect(ids).toContain('nvidia-nim/qwen-3.5-397b')
+  })
+
+  it('should have valid config for all models', () => {
+    for (const model of OPENSIN_MODELS) {
+      expect(model.id).toBeTruthy()
+      expect(model.provider).toBeTruthy()
+      expect(model.contextLimit).toBeGreaterThan(0)
+      expect(model.maxOutputTokens).toBeGreaterThan(0)
+      expect(model.capabilities.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('DEFAULT_CHAINS', () => {
+  it('should have 4 chains', () => {
+    expect(DEFAULT_CHAINS.length).toBe(4)
+  })
+
+  it('should have models in every chain', () => {
+    for (const chain of DEFAULT_CHAINS) {
+      expect(chain.models.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/packages/opensin-sdk/src/__tests__/heartbeat.test.ts
+++ b/packages/opensin-sdk/src/__tests__/heartbeat.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { HeartbeatSystem, createHeartbeatSystem } from '../heartbeat/index'
+import type { HeartbeatEvent, QueuedTask, TaskResult } from '../heartbeat/index'
+
+describe('HeartbeatSystem', () => {
+  let heartbeat: HeartbeatSystem
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    heartbeat = createHeartbeatSystem({
+      intervalMs: 1000,
+      healthReportIntervalMs: 0,
+      taskQueuePollIntervalMs: 0,
+      autoStart: false,
+      maxConsecutiveErrors: 3,
+      errorBackoffMs: 100,
+      maxErrorBackoffMs: 1000,
+      gracefulShutdownTimeoutMs: 5000,
+    })
+  })
+
+  afterEach(() => {
+    heartbeat.stop()
+    vi.useRealTimers()
+  })
+
+  it('should start in stopped state', () => {
+    const state = heartbeat.getState()
+    expect(state.status).toBe('stopped')
+    expect(state.beatCount).toBe(0)
+  })
+
+  it('should transition to running on start', () => {
+    const state = heartbeat.start()
+    expect(state.status).toBe('running')
+    expect(state.startedAt).toBeTruthy()
+  })
+
+  it('should not double-start', () => {
+    heartbeat.start()
+    const state = heartbeat.start()
+    expect(state.status).toBe('running')
+  })
+
+  it('should pause and resume', () => {
+    heartbeat.start()
+    const paused = heartbeat.pause()
+    expect(paused.status).toBe('paused')
+
+    const resumed = heartbeat.resume()
+    expect(resumed.status).toBe('running')
+  })
+
+  it('should stop cleanly', () => {
+    heartbeat.start()
+    const stopped = heartbeat.stop()
+    expect(stopped.status).toBe('stopped')
+  })
+
+  it('should emit beat events', () => {
+    const events: HeartbeatEvent[] = []
+    heartbeat.onEvent(e => events.push(e))
+
+    void (heartbeat as any).beat()
+
+    const beatEvents = events.filter(e => e.type === 'beat')
+    expect(beatEvents.length).toBeGreaterThanOrEqual(1)
+    expect(beatEvents[0].data.beatCount).toBe(1)
+  })
+
+  it('should process tasks from queue poller', async () => {
+    const processedTasks: string[] = []
+    const mockTasks: QueuedTask[] = [
+      { id: 't1', type: 'test', payload: {}, priority: 1, createdAt: new Date().toISOString() },
+      { id: 't2', type: 'test', payload: {}, priority: 2, createdAt: new Date().toISOString() },
+    ]
+
+    heartbeat.setTaskQueuePoller(async () => mockTasks)
+    heartbeat.setTaskProcessor(async (task) => {
+      processedTasks.push(task.id)
+      return { taskId: task.id, success: true, durationMs: 10 }
+    })
+
+    await (heartbeat as any).beat()
+
+    expect(processedTasks.length).toBe(2)
+    expect(processedTasks[0]).toBe('t2')
+  })
+
+  it('should increment beatCount on each beat', () => {
+    void (heartbeat as any).beat()
+    void (heartbeat as any).beat()
+    void (heartbeat as any).beat()
+
+    const state = heartbeat.getState()
+    expect(state.beatCount).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should track total tasks processed', async () => {
+    heartbeat.setTaskQueuePoller(async () => [
+      { id: 't1', type: 'test', payload: {}, priority: 1, createdAt: new Date().toISOString() },
+    ])
+    heartbeat.setTaskProcessor(async (task) => ({
+      taskId: task.id, success: true, durationMs: 5,
+    }))
+
+    await (heartbeat as any).beat()
+
+    expect(heartbeat.getState().totalTasksProcessed).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should report isRunning correctly', () => {
+    expect(heartbeat.isRunning()).toBe(false)
+    heartbeat.start()
+    expect(heartbeat.isRunning()).toBe(true)
+    heartbeat.stop()
+    expect(heartbeat.isRunning()).toBe(false)
+  })
+
+  it('should allow unsubscribing from events', () => {
+    const events: HeartbeatEvent[] = []
+    const unsub = heartbeat.onEvent(e => events.push(e))
+
+    void (heartbeat as any).beat()
+    unsub()
+    void (heartbeat as any).beat()
+
+    const beatCount = events.filter(e => e.type === 'beat').length
+    expect(beatCount).toBe(1)
+  })
+
+  it('should process tasks in priority order (highest first)', async () => {
+    const order: number[] = []
+    heartbeat.setTaskQueuePoller(async () => [
+      { id: 'low', type: 'test', payload: {}, priority: 1, createdAt: new Date().toISOString() },
+      { id: 'high', type: 'test', payload: {}, priority: 10, createdAt: new Date().toISOString() },
+      { id: 'mid', type: 'test', payload: {}, priority: 5, createdAt: new Date().toISOString() },
+    ])
+    heartbeat.setTaskProcessor(async (task) => {
+      order.push(task.priority)
+      return { taskId: task.id, success: true, durationMs: 5 }
+    })
+
+    await (heartbeat as any).beat()
+
+    expect(order).toEqual([10, 5, 1])
+  })
+})
+
+describe('createHeartbeatSystem', () => {
+  it('should create instance with defaults', () => {
+    const hb = createHeartbeatSystem()
+    expect(hb.getState().status).toBe('stopped')
+    hb.stop()
+  })
+
+  it('should accept partial config overrides', () => {
+    const hb = createHeartbeatSystem({ intervalMs: 60000 })
+    expect(hb.getState().status).toBe('stopped')
+    hb.stop()
+  })
+})

--- a/packages/opensin-sdk/src/__tests__/orchestrator.test.ts
+++ b/packages/opensin-sdk/src/__tests__/orchestrator.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { AgentOrchestrator, createOrchestrator } from '../orchestrator/index'
+
+describe('AgentOrchestrator', () => {
+  let orchestrator: AgentOrchestrator
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    orchestrator = createOrchestrator({
+      heartbeat: {
+        intervalMs: 1000,
+        healthReportIntervalMs: 0,
+        taskQueuePollIntervalMs: 0,
+        autoStart: false,
+        maxConsecutiveErrors: 3,
+        errorBackoffMs: 100,
+        maxErrorBackoffMs: 1000,
+        gracefulShutdownTimeoutMs: 5000,
+      },
+      cronCheckIntervalMs: 1000,
+    })
+  })
+
+  afterEach(async () => {
+    await orchestrator.stop()
+    vi.useRealTimers()
+  })
+
+  it('should start in idle state', () => {
+    const state = orchestrator.getState()
+    expect(state.status).toBe('idle')
+    expect(state.heartbeatStatus).toBe('stopped')
+    expect(state.cronTaskCount).toBe(0)
+  })
+
+  it('should start all subsystems', () => {
+    const state = orchestrator.start()
+    expect(state.status).toBe('running')
+    expect(state.heartbeatStatus).toBe('running')
+  })
+
+  it('should pause all subsystems', () => {
+    orchestrator.start()
+    const state = orchestrator.pause()
+    expect(state.status).toBe('paused')
+  })
+
+  it('should resume all subsystems', () => {
+    orchestrator.start()
+    orchestrator.pause()
+    const state = orchestrator.resume()
+    expect(state.status).toBe('running')
+  })
+
+  it('should stop all subsystems', async () => {
+    orchestrator.start()
+    const state = await orchestrator.stop()
+    expect(state.status).toBe('idle')
+  })
+
+  it('should auto-approve safe actions', async () => {
+    const result = await orchestrator.evaluateAction('read_file', { path: '/test.txt' })
+    expect(result.approved).toBe(true)
+  })
+
+  it('should block destructive actions', async () => {
+    const result = await orchestrator.evaluateAction('delete_file', { path: '/test.txt' })
+    expect(result.approved).toBe(false)
+    expect(result.riskLevel).toBe('approve')
+  })
+
+  it('should resolve approval requests', async () => {
+    await orchestrator.evaluateAction('delete_file', { path: '/test.txt' })
+    const pending = orchestrator.getApproval().getPendingRequests()
+    expect(pending.length).toBe(1)
+
+    const resolved = orchestrator.resolveApproval({
+      requestId: pending[0].id,
+      decision: 'approve',
+      resolvedBy: 'admin',
+    })
+    expect(resolved).not.toBeNull()
+    expect(resolved!.status).toBe('approved')
+  })
+
+  it('should route models with failover and smart routing', () => {
+    const result = orchestrator.routeModel('Hello world', { requiresToolUse: true })
+    expect(result.selectedModel).toBeDefined()
+    expect(result.selectedModel.id).toBe('openai/gpt-5.4')
+    expect(result.routingDecision).toBeDefined()
+  })
+
+  it('should route to fast chain when preferSpeed', () => {
+    const result = orchestrator.routeModel('Quick', { preferSpeed: true })
+    expect(result.selectedModel.id).toBe('google/antigravity-gemini-3-flash')
+  })
+
+  it('should add cron tasks', () => {
+    const task = orchestrator.addCronTask({
+      name: 'Daily Report',
+      cronExpression: '0 9 * * *',
+      prompt: 'Generate daily report',
+      enabled: true,
+      timeoutMs: 60000,
+      retryOnFailure: false,
+      maxRetries: 0,
+      metadata: {},
+    })
+    expect(task.id).toBeTruthy()
+    expect(orchestrator.getState().cronTaskCount).toBe(1)
+  })
+
+  it('should add approval rules', async () => {
+    orchestrator.addApprovalRule({
+      id: 'custom-block',
+      name: 'Block custom',
+      actionPatterns: ['custom_*'],
+      riskLevel: 'approve',
+      conditions: [],
+      timeoutMs: 60000,
+      timeoutAction: 'reject',
+      enabled: true,
+      metadata: {},
+    })
+
+    const result = await orchestrator.evaluateAction('custom_action', {})
+    expect(result.approved).toBe(false)
+  })
+
+  it('should report model failures', () => {
+    orchestrator.reportModelFailure('openai/gpt-5.4', 'rate_limit')
+    const health = orchestrator.getFailover().getModelHealth('openai/gpt-5.4')
+    expect(health!.failures).toBe(1)
+  })
+
+  it('should report model successes', () => {
+    orchestrator.reportModelFailure('openai/gpt-5.4', 'error')
+    orchestrator.reportModelSuccess('openai/gpt-5.4')
+    const health = orchestrator.getFailover().getModelHealth('openai/gpt-5.4')
+    expect(health!.failures).toBe(0)
+  })
+
+  it('should expose all subsystems', () => {
+    expect(orchestrator.getHeartbeat()).toBeDefined()
+    expect(orchestrator.getCron()).toBeDefined()
+    expect(orchestrator.getFailover()).toBeDefined()
+    expect(orchestrator.getApproval()).toBeDefined()
+    expect(orchestrator.getRouter()).toBeDefined()
+    expect(orchestrator.getPermissionEvaluator()).toBeDefined()
+  })
+
+  it('should emit orchestrator events', () => {
+    const events: import('../orchestrator/index').OrchestratorEvent[] = []
+    orchestrator.onEvent(e => events.push(e))
+
+    orchestrator.start()
+    const started = events.find(e => e.type === 'started')
+    expect(started).toBeDefined()
+  })
+
+  it('should allow unsubscribing from events', () => {
+    const events: import('../orchestrator/index').OrchestratorEvent[] = []
+    const unsub = orchestrator.onEvent(e => events.push(e))
+
+    orchestrator.start()
+    unsub()
+    orchestrator.pause()
+
+    const hasPaused = events.some(e => e.type === 'paused')
+    expect(hasPaused).toBe(false)
+  })
+
+  it('should track uptime', () => {
+    orchestrator.start()
+    const state = orchestrator.getState()
+    expect(state.uptimeMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('should track pending approvals count', async () => {
+    await orchestrator.evaluateAction('delete_file', { path: '/a.txt' })
+    await orchestrator.evaluateAction('deploy_production', { env: 'prod' })
+
+    const state = orchestrator.getState()
+    expect(state.pendingApprovals).toBe(2)
+  })
+})
+
+describe('createOrchestrator', () => {
+  it('should create instance with defaults', () => {
+    const orch = createOrchestrator()
+    expect(orch.getState().status).toBe('idle')
+  })
+
+  it('should accept config overrides', () => {
+    const orch = createOrchestrator({
+      cronCheckIntervalMs: 5000,
+    })
+    expect(orch.getState().status).toBe('idle')
+  })
+})

--- a/packages/opensin-sdk/src/approval/index.ts
+++ b/packages/opensin-sdk/src/approval/index.ts
@@ -1,0 +1,352 @@
+/**
+ * OpenSIN Approval Hooks — Safety gates for autonomous operations
+ *
+ * Like OpenClaw's requireApproval, this system provides risk-based approval
+ * gates that require human confirmation before high-risk autonomous actions.
+ */
+
+export type RiskLevel = 'auto' | 'notify' | 'approve';
+
+export interface ApprovalRule {
+  id: string;
+  name: string;
+  actionPatterns: string[];
+  riskLevel: RiskLevel;
+  conditions: ApprovalCondition[];
+  timeoutMs: number;
+  timeoutAction: 'reject' | 'approve' | 'escalate';
+  enabled: boolean;
+  metadata: Record<string, unknown>;
+}
+
+export interface ApprovalCondition {
+  field: string;
+  operator: 'eq' | 'neq' | 'gt' | 'lt' | 'contains' | 'matches' | 'in';
+  value: string | number | boolean | string[];
+}
+
+export interface ApprovalRequest {
+  id: string;
+  ruleId: string;
+  action: string;
+  input: Record<string, unknown>;
+  riskLevel: RiskLevel;
+  status: 'pending' | 'approved' | 'rejected' | 'expired' | 'escalated';
+  requestedAt: string;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  reason?: string;
+  timeoutMs: number;
+  expiresAt: string;
+}
+
+export interface ApprovalDecision {
+  requestId: string;
+  decision: 'approve' | 'reject';
+  resolvedBy: string;
+  reason?: string;
+}
+
+export interface ApprovalEvent {
+  type: 'request_created' | 'approved' | 'rejected' | 'expired' | 'escalated';
+  timestamp: string;
+  requestId: string;
+  data: Record<string, unknown>;
+}
+
+const DEFAULT_RULES: ApprovalRule[] = [
+  {
+    id: 'auto-safe-ops',
+    name: 'Auto-approve safe operations',
+    actionPatterns: ['read_file', 'glob', 'grep', 'search', 'list', 'status', 'health', 'info'],
+    riskLevel: 'auto',
+    conditions: [],
+    timeoutMs: 0,
+    timeoutAction: 'approve',
+    enabled: true,
+    metadata: {},
+  },
+  {
+    id: 'notify-write-ops',
+    name: 'Notify on write operations',
+    actionPatterns: ['write_file', 'edit_file', 'create_*', 'update_*'],
+    riskLevel: 'notify',
+    conditions: [],
+    timeoutMs: 300000,
+    timeoutAction: 'approve',
+    enabled: true,
+    metadata: {},
+  },
+  {
+    id: 'approve-destructive-ops',
+    name: 'Require approval for destructive operations',
+    actionPatterns: ['delete_*', 'remove_*', 'rm_*', 'drop_*', 'truncate_*', 'destroy_*'],
+    riskLevel: 'approve',
+    conditions: [],
+    timeoutMs: 600000,
+    timeoutAction: 'reject',
+    enabled: true,
+    metadata: {},
+  },
+  {
+    id: 'approve-network-ops',
+    name: 'Require approval for external network calls',
+    actionPatterns: ['deploy_*', 'publish_*', 'send_*', 'webhook_*', 'api_*'],
+    riskLevel: 'approve',
+    conditions: [],
+    timeoutMs: 300000,
+    timeoutAction: 'reject',
+    enabled: true,
+    metadata: {},
+  },
+  {
+    id: 'approve-financial-ops',
+    name: 'Require approval for financial operations',
+    actionPatterns: ['payment_*', 'charge_*', 'refund_*', 'transfer_*', 'stripe_*'],
+    riskLevel: 'approve',
+    conditions: [],
+    timeoutMs: 900000,
+    timeoutAction: 'reject',
+    enabled: true,
+    metadata: {},
+  },
+  {
+    id: 'approve-auth-ops',
+    name: 'Require approval for auth/security operations',
+    actionPatterns: ['auth_*', 'token_*', 'credential_*', 'secret_*', 'key_*', 'password_*'],
+    riskLevel: 'approve',
+    conditions: [],
+    timeoutMs: 300000,
+    timeoutAction: 'reject',
+    enabled: true,
+    metadata: {},
+  },
+];
+
+export class ApprovalHooks {
+  private rules: Map<string, ApprovalRule> = new Map();
+  private pendingRequests: Map<string, ApprovalRequest> = new Map();
+  private auditLog: ApprovalRequest[] = [];
+  private eventListeners: ((event: ApprovalEvent) => void)[] = [];
+  private notificationChannel: ((request: ApprovalRequest) => Promise<void>) | null = null;
+  private expiryChecker: ReturnType<typeof setInterval> | null = null;
+
+  constructor(rules?: ApprovalRule[]) {
+    const initialRules = rules || DEFAULT_RULES;
+    for (const rule of initialRules) {
+      this.rules.set(rule.id, rule);
+    }
+    this.startExpiryChecker();
+  }
+
+  setNotificationChannel(channel: (request: ApprovalRequest) => Promise<void>): void {
+    this.notificationChannel = channel;
+  }
+
+  async evaluateAction(
+    action: string,
+    input: Record<string, unknown>,
+  ): Promise<{ approved: boolean; riskLevel: RiskLevel; requestId?: string; ruleId?: string }> {
+    const matchingRule = this.findMatchingRule(action, input);
+
+    if (!matchingRule) {
+      return { approved: true, riskLevel: 'auto' };
+    }
+
+    switch (matchingRule.riskLevel) {
+      case 'auto':
+        return { approved: true, riskLevel: 'auto', ruleId: matchingRule.id };
+
+      case 'notify': {
+        const request = this.createRequest(matchingRule, action, input);
+        if (this.notificationChannel) {
+          await this.notificationChannel(request);
+        }
+        return { approved: true, riskLevel: 'notify', requestId: request.id, ruleId: matchingRule.id };
+      }
+
+      case 'approve': {
+        const request = this.createRequest(matchingRule, action, input);
+        if (this.notificationChannel) {
+          await this.notificationChannel(request);
+        }
+        return { approved: false, riskLevel: 'approve', requestId: request.id, ruleId: matchingRule.id };
+      }
+    }
+  }
+
+  resolveRequest(decision: ApprovalDecision): ApprovalRequest | null {
+    const request = this.pendingRequests.get(decision.requestId);
+    if (!request || request.status !== 'pending') return null;
+
+    request.status = decision.decision === 'approve' ? 'approved' : 'rejected';
+    request.resolvedAt = new Date().toISOString();
+    request.resolvedBy = decision.resolvedBy;
+    request.reason = decision.reason;
+
+    this.pendingRequests.delete(decision.requestId);
+    this.auditLog.push(request);
+
+    this.emitEvent(decision.decision === 'approve' ? 'approved' : 'rejected', request.id, {
+      resolvedBy: decision.resolvedBy,
+      reason: decision.reason,
+    });
+
+    return request;
+  }
+
+  getPendingRequests(): ApprovalRequest[] {
+    return Array.from(this.pendingRequests.values());
+  }
+
+  getAuditLog(limit = 100): ApprovalRequest[] {
+    return this.auditLog.slice(-limit);
+  }
+
+  addRule(rule: ApprovalRule): void {
+    this.rules.set(rule.id, rule);
+  }
+
+  removeRule(ruleId: string): boolean {
+    return this.rules.delete(ruleId);
+  }
+
+  updateRule(ruleId: string, updates: Partial<ApprovalRule>): ApprovalRule | undefined {
+    const rule = this.rules.get(ruleId);
+    if (!rule) return undefined;
+    const updated = { ...rule, ...updates };
+    this.rules.set(ruleId, updated);
+    return updated;
+  }
+
+  listRules(enabledOnly = false): ApprovalRule[] {
+    const all = Array.from(this.rules.values());
+    return enabledOnly ? all.filter(r => r.enabled) : all;
+  }
+
+  onEvent(listener: (event: ApprovalEvent) => void): () => void {
+    this.eventListeners.push(listener);
+    return () => {
+      this.eventListeners = this.eventListeners.filter(l => l !== listener);
+    };
+  }
+
+  destroy(): void {
+    if (this.expiryChecker) {
+      clearInterval(this.expiryChecker);
+      this.expiryChecker = null;
+    }
+  }
+
+  private findMatchingRule(action: string, input: Record<string, unknown>): ApprovalRule | null {
+    const enabledRules = Array.from(this.rules.values()).filter(r => r.enabled);
+
+    const sortedByPriority = enabledRules.sort((a, b) => {
+      const priorityMap: Record<RiskLevel, number> = { approve: 3, notify: 2, auto: 1 };
+      return priorityMap[b.riskLevel] - priorityMap[a.riskLevel];
+    });
+
+    for (const rule of sortedByPriority) {
+      const matchesAction = rule.actionPatterns.some(pattern => {
+        if (pattern.includes('*')) {
+          const regex = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+          return regex.test(action);
+        }
+        return action === pattern;
+      });
+
+      if (!matchesAction) continue;
+
+      if (rule.conditions.length === 0) return rule;
+
+      const allConditionsMet = rule.conditions.every(condition =>
+        this.evaluateCondition(condition, input),
+      );
+
+      if (allConditionsMet) return rule;
+    }
+
+    return null;
+  }
+
+  private evaluateCondition(condition: ApprovalCondition, input: Record<string, unknown>): boolean {
+    const fieldValue = input[condition.field];
+
+    switch (condition.operator) {
+      case 'eq': return fieldValue === condition.value;
+      case 'neq': return fieldValue !== condition.value;
+      case 'gt': return typeof fieldValue === 'number' && fieldValue > (condition.value as number);
+      case 'lt': return typeof fieldValue === 'number' && fieldValue < (condition.value as number);
+      case 'contains': return typeof fieldValue === 'string' && fieldValue.includes(condition.value as string);
+      case 'matches': {
+        if (typeof fieldValue !== 'string') return false;
+        try { return new RegExp(condition.value as string).test(fieldValue); } catch { return false; }
+      }
+      case 'in': return Array.isArray(condition.value) && condition.value.includes(String(fieldValue));
+      default: return false;
+    }
+  }
+
+  private createRequest(rule: ApprovalRule, action: string, input: Record<string, unknown>): ApprovalRequest {
+    const request: ApprovalRequest = {
+      id: `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      ruleId: rule.id,
+      action,
+      input,
+      riskLevel: rule.riskLevel,
+      status: 'pending',
+      requestedAt: new Date().toISOString(),
+      resolvedAt: null,
+      resolvedBy: null,
+      timeoutMs: rule.timeoutMs,
+      expiresAt: new Date(Date.now() + rule.timeoutMs).toISOString(),
+    };
+
+    this.pendingRequests.set(request.id, request);
+    this.emitEvent('request_created', request.id, { action, riskLevel: rule.riskLevel, ruleName: rule.name });
+
+    return request;
+  }
+
+  private startExpiryChecker(): void {
+    this.expiryChecker = setInterval(() => {
+      this.checkExpiredRequests();
+    }, 30000);
+  }
+
+  private checkExpiredRequests(): void {
+    const now = new Date();
+
+    for (const [id, request] of this.pendingRequests) {
+      if (request.status !== 'pending') continue;
+
+      if (now >= new Date(request.expiresAt)) {
+        const rule = this.rules.get(request.ruleId);
+        const timeoutAction = rule?.timeoutAction || 'reject';
+
+        request.status = timeoutAction === 'approve' ? 'approved' : timeoutAction === 'escalate' ? 'escalated' : 'expired';
+        request.resolvedAt = new Date().toISOString();
+        request.resolvedBy = 'system:timeout';
+        request.reason = `Request expired after ${request.timeoutMs}ms`;
+
+        this.pendingRequests.delete(id);
+        this.auditLog.push(request);
+
+        this.emitEvent('expired', id, { timeoutAction, ruleId: request.ruleId });
+      }
+    }
+  }
+
+  private emitEvent(type: ApprovalEvent['type'], requestId: string, data: Record<string, unknown>): void {
+    const event: ApprovalEvent = { type, timestamp: new Date().toISOString(), requestId, data };
+    for (const listener of this.eventListeners) {
+      try { listener(event); } catch { }
+    }
+  }
+}
+
+export function createApprovalHooks(rules?: ApprovalRule[]): ApprovalHooks {
+  return new ApprovalHooks(rules);
+}
+
+export { DEFAULT_RULES };

--- a/packages/opensin-sdk/src/cli-agent/agent.ts
+++ b/packages/opensin-sdk/src/cli-agent/agent.ts
@@ -16,11 +16,13 @@ import type {
 import { SessionManager } from "./session.js";
 import { ToolRegistry, createBuiltinTools } from "./tools.js";
 import { createDefaultConfig, validateConfig } from "./config.js";
+import { createOrchestrator, type AgentOrchestrator } from "../orchestrator/index.js";
 
 export class CLIAgent {
   private config: CLIAgentConfig;
   private sessionManager: SessionManager;
   private toolRegistry: ToolRegistry;
+  private orchestrator: AgentOrchestrator;
   private eventListeners: Set<(event: CLIEvent) => void> = new Set();
   private state: CLIAgentState;
   private approvalQueue: ToolCallRecord[] = [];
@@ -31,6 +33,7 @@ export class CLIAgent {
     this.config = createDefaultConfig(config);
     this.sessionManager = new SessionManager();
     this.toolRegistry = new ToolRegistry();
+    this.orchestrator = createOrchestrator();
     this.state = {
       session: this.sessionManager.createSession(this.config),
       config: this.config,
@@ -212,6 +215,10 @@ export class CLIAgent {
     return this.toolRegistry.list();
   }
 
+  getOrchestrator(): AgentOrchestrator {
+    return this.orchestrator;
+  }
+
   private async generateAssistantResponse(userInput: string, files?: string[]): Promise<void> {
     this.state.isStreaming = true;
 
@@ -226,6 +233,16 @@ export class CLIAgent {
 
     const context = this.buildContextString(files);
     const prompt = this.buildPrompt(context, userInput);
+
+    const routing = this.orchestrator.routeModel(prompt, {
+      requiresToolUse: true,
+      preferSpeed: this.config.batchMode,
+      requiresLongContext: Boolean(files && files.length > 3),
+    });
+
+    this.config.model = routing.selectedModel.id;
+    this.config.provider = routing.selectedModel.provider;
+    this.state.config = this.config;
 
     const response = await this.callLLM(prompt);
     assistantMessage.content = response;
@@ -245,11 +262,27 @@ export class CLIAgent {
       const tool = this.toolRegistry.get(toolCall.toolName);
       if (!tool) continue;
 
-      const needsApproval = tool.requiresApproval && !this.config.autoApproveTools.includes(toolCall.toolName);
+      const policy = await this.orchestrator.evaluateAction(toolCall.toolName, toolCall.parameters);
 
-      if (needsApproval && this.config.interactive) {
+      const needsApproval = tool.requiresApproval && !this.config.autoApproveTools.includes(toolCall.toolName);
+      const blockedByPolicy = !policy.approved;
+
+      if ((needsApproval || blockedByPolicy) && this.config.interactive) {
         this.approvalQueue.push(toolCall);
         this.emit({ type: "approval:required", toolCall });
+        continue;
+      }
+
+      if (blockedByPolicy) {
+        toolCall.approved = false;
+        toolCall.result = {
+          success: false,
+          output: "",
+          error: `Tool call blocked by policy (${policy.riskLevel})`,
+          exitCode: 1,
+        };
+        this.sessionManager.addToolCall(this.config.sessionId, toolCall);
+        this.emit({ type: "tool:error", toolCall, error: toolCall.result.error ?? "Tool call blocked by policy" });
         continue;
       }
 

--- a/packages/opensin-sdk/src/cron/index.ts
+++ b/packages/opensin-sdk/src/cron/index.ts
@@ -1,0 +1,351 @@
+/**
+ * OpenSIN Cron Scheduler — Scheduled recurring task execution
+ *
+ * Cron-style scheduling for recurring autonomous tasks (daily summaries,
+ * weekly reports, periodic health checks). Matches Gemini Scheduled Actions
+ * and Claude Code /loop capabilities.
+ */
+
+export interface CronTask {
+  id: string;
+  name: string;
+  cronExpression: string;
+  prompt: string;
+  enabled: boolean;
+  maxExecutions?: number;
+  executionCount: number;
+  lastExecutedAt: string | null;
+  nextExecutionAt: string | null;
+  createdAt: string;
+  metadata: Record<string, unknown>;
+  chainId?: string;
+  timeoutMs: number;
+  retryOnFailure: boolean;
+  maxRetries: number;
+}
+
+export interface CronExecution {
+  id: string;
+  taskId: string;
+  startedAt: string;
+  completedAt: string | null;
+  status: 'running' | 'completed' | 'failed' | 'timeout';
+  result?: string;
+  error?: string;
+  durationMs: number;
+  attempt: number;
+}
+
+export type CronExecutor = (prompt: string, task: CronTask) => Promise<string>;
+
+export interface CronEvent {
+  type: 'task_created' | 'task_started' | 'task_completed' | 'task_failed' | 'task_timeout' | 'schedule_updated';
+  timestamp: string;
+  taskId: string;
+  data: Record<string, unknown>;
+}
+
+const MONTH_DAYS = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+const DAY_NAMES = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+
+export function parseCronExpression(expr: string): {
+  minute: number[];
+  hour: number[];
+  dayOfMonth: number[];
+  month: number[];
+  dayOfWeek: number[];
+} | null {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+
+  const parseField = (field: string, min: number, max: number): number[] | null => {
+    if (field === '*') return Array.from({ length: max - min + 1 }, (_, i) => min + i);
+
+    const values: number[] = [];
+    for (const part of field.split(',')) {
+      if (part.includes('/')) {
+        const [range, step] = part.split('/');
+        const stepNum = parseInt(step, 10);
+        if (isNaN(stepNum)) return null;
+        const start = range === '*' ? min : parseInt(range, 10);
+        if (isNaN(start)) return null;
+        for (let i = start; i <= max; i += stepNum) values.push(i);
+      } else if (part.includes('-')) {
+        const [from, to] = part.split('-').map(n => parseInt(n, 10));
+        if (isNaN(from) || isNaN(to)) return null;
+        for (let i = from; i <= to; i++) values.push(i);
+      } else {
+        const num = parseInt(part, 10);
+        if (isNaN(num)) return null;
+        values.push(num);
+      }
+    }
+    const filtered = values.filter(v => v >= min && v <= max);
+    if (values.length > 0 && filtered.length === 0) return null;
+    return filtered;
+  };
+
+  const minute = parseField(parts[0], 0, 59);
+  const hour = parseField(parts[1], 0, 23);
+  const dayOfMonth = parseField(parts[2], 1, 31);
+  const month = parseField(parts[3], 1, 12);
+  const dayOfWeek = parseField(parts[4], 0, 6);
+
+  if (!minute || !hour || !dayOfMonth || !month || !dayOfWeek) return null;
+
+  return { minute, hour, dayOfMonth, month, dayOfWeek };
+}
+
+export function getNextExecution(parsed: ReturnType<typeof parseCronExpression>, after: Date = new Date()): Date | null {
+  if (!parsed) return null;
+
+  const start = new Date(after.getTime() + 60000);
+  start.setSeconds(0, 0);
+
+  for (let monthOffset = 0; monthOffset < 24; monthOffset++) {
+    const testMonth = ((start.getMonth() + monthOffset) % 12) + 1;
+    if (!parsed.month.includes(testMonth)) continue;
+
+    const year = start.getFullYear() + Math.floor((start.getMonth() + monthOffset) / 12);
+
+    for (const day of parsed.dayOfMonth) {
+      if (day > MONTH_DAYS[testMonth - 1]) continue;
+
+      for (const hour of parsed.hour) {
+        for (const minute of parsed.minute) {
+          const candidate = new Date(year, testMonth - 1, day, hour, minute, 0, 0);
+          if (candidate <= after) continue;
+
+          const dow = candidate.getDay();
+          if (parsed.dayOfWeek.includes(dow)) {
+            return candidate;
+          }
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export class CronScheduler {
+  private tasks: Map<string, CronTask> = new Map();
+  private executions: Map<string, CronExecution> = new Map();
+  private executor: CronExecutor | null = null;
+  private checkInterval: ReturnType<typeof setInterval> | null = null;
+  private eventListeners: ((event: CronEvent) => void)[] = [];
+  private checkIntervalMs: number;
+  private running = false;
+
+  constructor(executor?: CronExecutor, checkIntervalMs = 60000) {
+    this.executor = executor || null;
+    this.checkIntervalMs = checkIntervalMs;
+  }
+
+  setExecutor(executor: CronExecutor): void {
+    this.executor = executor;
+  }
+
+  createTask(config: Omit<CronTask, 'id' | 'executionCount' | 'lastExecutedAt' | 'nextExecutionAt' | 'createdAt'>): CronTask {
+    const parsed = parseCronExpression(config.cronExpression);
+    if (!parsed) throw new Error(`Invalid cron expression: ${config.cronExpression}`);
+
+    const nextExec = getNextExecution(parsed);
+
+    const task: CronTask = {
+      ...config,
+      id: `cron-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      executionCount: 0,
+      lastExecutedAt: null,
+      nextExecutionAt: nextExec?.toISOString() || null,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.tasks.set(task.id, task);
+    this.emitEvent('task_created', task.id, { name: task.name, cronExpression: task.cronExpression });
+
+    return task;
+  }
+
+  getTask(taskId: string): CronTask | undefined {
+    return this.tasks.get(taskId);
+  }
+
+  listTasks(enabledOnly = false): CronTask[] {
+    const all = Array.from(this.tasks.values());
+    return enabledOnly ? all.filter(t => t.enabled) : all;
+  }
+
+  updateTask(taskId: string, updates: Partial<CronTask>): CronTask | undefined {
+    const task = this.tasks.get(taskId);
+    if (!task) return undefined;
+
+    const updated = { ...task, ...updates };
+
+    if (updates.cronExpression && updates.cronExpression !== task.cronExpression) {
+      const parsed = parseCronExpression(updates.cronExpression);
+      if (!parsed) throw new Error(`Invalid cron expression: ${updates.cronExpression}`);
+      updated.nextExecutionAt = getNextExecution(parsed)?.toISOString() || null;
+    }
+
+    this.tasks.set(taskId, updated);
+    this.emitEvent('schedule_updated', taskId, { updates });
+
+    return updated;
+  }
+
+  deleteTask(taskId: string): boolean {
+    return this.tasks.delete(taskId);
+  }
+
+  enableTask(taskId: string): CronTask | undefined {
+    return this.updateTask(taskId, { enabled: true });
+  }
+
+  disableTask(taskId: string): CronTask | undefined {
+    return this.updateTask(taskId, { enabled: false });
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+
+    this.checkInterval = setInterval(() => {
+      this.checkAndExecute().catch(err => {
+        this.emitEvent('task_failed', 'scheduler', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, this.checkIntervalMs);
+  }
+
+  stop(): void {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+    }
+    this.running = false;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  getExecutions(taskId?: string, limit = 50): CronExecution[] {
+    let all = Array.from(this.executions.values());
+    if (taskId) all = all.filter(e => e.taskId === taskId);
+    return all.sort((a, b) => b.startedAt.localeCompare(a.startedAt)).slice(0, limit);
+  }
+
+  onEvent(listener: (event: CronEvent) => void): () => void {
+    this.eventListeners.push(listener);
+    return () => {
+      this.eventListeners = this.eventListeners.filter(l => l !== listener);
+    };
+  }
+
+  private async checkAndExecute(): Promise<void> {
+    const now = new Date();
+
+    for (const task of this.tasks.values()) {
+      if (!task.enabled) continue;
+      if (task.maxExecutions && task.executionCount >= task.maxExecutions) continue;
+
+      if (!task.nextExecutionAt) {
+        const parsed = parseCronExpression(task.cronExpression);
+        const next = getNextExecution(parsed);
+        if (next) {
+          task.nextExecutionAt = next.toISOString();
+        }
+        continue;
+      }
+
+      const nextTime = new Date(task.nextExecutionAt);
+      if (now >= nextTime) {
+        await this.executeTask(task);
+      }
+    }
+  }
+
+  private async executeTask(task: CronTask): Promise<void> {
+    if (!this.executor) return;
+
+    const execution: CronExecution = {
+      id: `exec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      taskId: task.id,
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      status: 'running',
+      durationMs: 0,
+      attempt: 1,
+    };
+
+    this.executions.set(execution.id, execution);
+    this.emitEvent('task_started', task.id, { executionId: execution.id });
+
+    const startTime = Date.now();
+    let attempts = 0;
+    const maxAttempts = task.retryOnFailure ? task.maxRetries + 1 : 1;
+
+    while (attempts < maxAttempts) {
+      attempts++;
+      execution.attempt = attempts;
+
+      try {
+        const result = await Promise.race([
+          this.executor(task.prompt, task),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('Execution timeout')), task.timeoutMs),
+          ),
+        ]);
+
+        execution.completedAt = new Date().toISOString();
+        execution.status = 'completed';
+        execution.result = result;
+        execution.durationMs = Date.now() - startTime;
+
+        task.executionCount++;
+        task.lastExecutedAt = execution.completedAt;
+
+        this.emitEvent('task_completed', task.id, {
+          executionId: execution.id,
+          durationMs: execution.durationMs,
+          result: result.substring(0, 500),
+        });
+        break;
+      } catch (error) {
+        const isTimeout = error instanceof Error && error.message === 'Execution timeout';
+        execution.error = error instanceof Error ? error.message : String(error);
+        execution.durationMs = Date.now() - startTime;
+
+        if (isTimeout) {
+          execution.status = 'timeout';
+          this.emitEvent('task_timeout', task.id, { executionId: execution.id });
+          break;
+        } else if (attempts >= maxAttempts) {
+          execution.status = 'failed';
+          execution.completedAt = new Date().toISOString();
+          this.emitEvent('task_failed', task.id, {
+            executionId: execution.id,
+            error: execution.error,
+            attempts,
+          });
+        }
+      }
+    }
+
+    const parsed = parseCronExpression(task.cronExpression);
+    task.nextExecutionAt = getNextExecution(parsed)?.toISOString() || null;
+  }
+
+  private emitEvent(type: CronEvent['type'], taskId: string, data: Record<string, unknown>): void {
+    const event: CronEvent = { type, timestamp: new Date().toISOString(), taskId, data };
+    for (const listener of this.eventListeners) {
+      try { listener(event); } catch { }
+    }
+  }
+}
+
+export function createCronScheduler(executor?: CronExecutor, checkIntervalMs?: number): CronScheduler {
+  return new CronScheduler(executor, checkIntervalMs);
+}

--- a/packages/opensin-sdk/src/heartbeat/index.ts
+++ b/packages/opensin-sdk/src/heartbeat/index.ts
@@ -1,0 +1,393 @@
+/**
+ * OpenSIN Heartbeat System — Periodic autonomous agent check-in
+ *
+ * Like OpenClaw's heartbeat, this system wakes the agent at configurable
+ * intervals to check for pending tasks, process queues, and execute
+ * scheduled work.
+ *
+ * Features:
+ * - Configurable heartbeat interval (default 30 min)
+ * - Task queue polling (Supabase-backed)
+ * - Graceful shutdown with state checkpointing
+ * - Health status reporting
+ * - Integration with LoopMode for recurring tasks
+ */
+
+import type { LoopMode } from '../loop/index.js';
+import type { AgentLoop } from '../agent_loop/agent_loop.js';
+
+export interface HeartbeatConfig {
+  intervalMs: number;
+  maxConsecutiveErrors: number;
+  errorBackoffMs: number;
+  maxErrorBackoffMs: number;
+  healthReportIntervalMs: number;
+  taskQueuePollIntervalMs: number;
+  gracefulShutdownTimeoutMs: number;
+  autoStart: boolean;
+}
+
+export const DEFAULT_HEARTBEAT_CONFIG: HeartbeatConfig = {
+  intervalMs: 30 * 60 * 1000,
+  maxConsecutiveErrors: 5,
+  errorBackoffMs: 5000,
+  maxErrorBackoffMs: 300000,
+  healthReportIntervalMs: 5 * 60 * 1000,
+  taskQueuePollIntervalMs: 60 * 1000,
+  gracefulShutdownTimeoutMs: 10000,
+  autoStart: true,
+};
+
+export type HeartbeatStatus =
+  | 'stopped'
+  | 'running'
+  | 'paused'
+  | 'error'
+  | 'shutting_down';
+
+export interface HeartbeatState {
+  status: HeartbeatStatus;
+  beatCount: number;
+  lastBeatAt: string | null;
+  nextBeatAt: string | null;
+  consecutiveErrors: number;
+  totalTasksProcessed: number;
+  startedAt: string | null;
+  lastHealthReportAt: string | null;
+  checkpoint: Record<string, unknown> | null;
+}
+
+export interface HeartbeatEvent {
+  type:
+    | 'beat'
+    | 'task_processed'
+    | 'error'
+    | 'health_report'
+    | 'shutdown'
+    | 'checkpoint'
+    | 'paused'
+    | 'resumed';
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+export type HeartbeatCallback = (event: HeartbeatEvent) => void | Promise<void>;
+export type TaskProcessor = (task: QueuedTask) => Promise<TaskResult>;
+export type TaskQueuePoller = () => Promise<QueuedTask[]>;
+
+export interface QueuedTask {
+  id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  priority: number;
+  createdAt: string;
+  scheduledFor?: string;
+  retries?: number;
+  maxRetries?: number;
+}
+
+export interface TaskResult {
+  taskId: string;
+  success: boolean;
+  output?: string;
+  error?: string;
+  durationMs: number;
+}
+
+export class HeartbeatSystem {
+  private config: HeartbeatConfig;
+  private state: HeartbeatState;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private healthTimer: ReturnType<typeof setInterval> | null = null;
+  private taskPollTimer: ReturnType<typeof setInterval> | null = null;
+  private taskProcessor: TaskProcessor | null = null;
+  private taskQueuePoller: TaskQueuePoller | null = null;
+  private eventCallbacks: HeartbeatCallback[] = [];
+  private shuttingDown = false;
+  private shutdownHandlersRegistered = false;
+  private readonly shutdownHandler = async (): Promise<void> => {
+    if (this.shuttingDown) return;
+    await this.gracefulShutdown();
+  };
+
+  constructor(config?: Partial<HeartbeatConfig>) {
+    this.config = { ...DEFAULT_HEARTBEAT_CONFIG, ...config };
+    this.state = {
+      status: 'stopped',
+      beatCount: 0,
+      lastBeatAt: null,
+      nextBeatAt: null,
+      consecutiveErrors: 0,
+      totalTasksProcessed: 0,
+      startedAt: null,
+      lastHealthReportAt: null,
+      checkpoint: null,
+    };
+  }
+
+  setTaskProcessor(processor: TaskProcessor): void {
+    this.taskProcessor = processor;
+  }
+
+  setTaskQueuePoller(poller: TaskQueuePoller): void {
+    this.taskQueuePoller = poller;
+  }
+
+  onEvent(callback: HeartbeatCallback): () => void {
+    this.eventCallbacks.push(callback);
+    return () => {
+      this.eventCallbacks = this.eventCallbacks.filter(cb => cb !== callback);
+    };
+  }
+
+  start(): HeartbeatState {
+    if (this.state.status === 'running') {
+      return this.state;
+    }
+
+    this.state.status = 'running';
+    this.state.startedAt = new Date().toISOString();
+    this.shuttingDown = false;
+
+    this.scheduleNextBeat();
+
+    if (this.taskQueuePoller) {
+      this.taskPollTimer = setInterval(
+        () => this.pollTaskQueue(),
+        this.config.taskQueuePollIntervalMs,
+      );
+    }
+
+    if (this.config.healthReportIntervalMs > 0) {
+      this.healthTimer = setInterval(
+        () => this.emitHealthReport(),
+        this.config.healthReportIntervalMs,
+      );
+    }
+
+    this.registerShutdownHandlers();
+
+    return this.state;
+  }
+
+  pause(): HeartbeatState {
+    if (this.state.status !== 'running') return this.state;
+
+    this.clearTimers();
+    this.state.status = 'paused';
+    this.emitEvent('paused', {});
+    return this.state;
+  }
+
+  resume(): HeartbeatState {
+    if (this.state.status !== 'paused') return this.state;
+
+    this.state.status = 'running';
+    this.scheduleNextBeat();
+    this.emitEvent('resumed', {});
+    return this.state;
+  }
+
+  stop(): HeartbeatState {
+    this.clearTimers();
+    this.removeShutdownHandlers();
+    this.state.status = 'stopped';
+    this.emitEvent('shutdown', { reason: 'manual_stop' });
+    return this.state;
+  }
+
+  async gracefulShutdown(): Promise<HeartbeatState> {
+    this.shuttingDown = true;
+    this.state.status = 'shutting_down';
+    this.emitEvent('shutdown', { reason: 'graceful', checkpoint: this.state.checkpoint });
+
+    this.clearTimers();
+    this.removeShutdownHandlers();
+
+    await this.checkpoint();
+
+    this.state.status = 'stopped';
+    return this.state;
+  }
+
+  getState(): HeartbeatState {
+    return { ...this.state };
+  }
+
+  isRunning(): boolean {
+    return this.state.status === 'running';
+  }
+
+  private scheduleNextBeat(): void {
+    if (this.timer) clearInterval(this.timer);
+
+    const intervalMs = this.getEffectiveInterval();
+
+    this.state.nextBeatAt = new Date(Date.now() + intervalMs).toISOString();
+
+    this.timer = setInterval(() => {
+      this.beat().catch(err => {
+        this.handleError(err instanceof Error ? err : new Error(String(err)));
+      });
+    }, intervalMs);
+  }
+
+  private getEffectiveInterval(): number {
+    if (this.state.consecutiveErrors > 0) {
+      const backoff =
+        this.config.errorBackoffMs *
+        Math.pow(2, this.state.consecutiveErrors - 1);
+      return Math.min(backoff, this.config.maxErrorBackoffMs);
+    }
+    return this.config.intervalMs;
+  }
+
+  private async beat(): Promise<void> {
+    this.state.beatCount++;
+    this.state.lastBeatAt = new Date().toISOString();
+    this.state.consecutiveErrors = 0;
+
+    this.emitEvent('beat', {
+      beatCount: this.state.beatCount,
+      tasksProcessed: this.state.totalTasksProcessed,
+    });
+
+    if (this.taskQueuePoller) {
+      await this.pollTaskQueue();
+    }
+
+    await this.checkpoint();
+
+    this.scheduleNextBeat();
+  }
+
+  private async pollTaskQueue(): Promise<void> {
+    if (!this.taskQueuePoller || !this.taskProcessor) return;
+
+    try {
+      const tasks = await this.taskQueuePoller();
+
+      const sorted = tasks.sort((a, b) => b.priority - a.priority);
+
+      for (const task of sorted) {
+        try {
+          const result = await this.taskProcessor(task);
+          this.state.totalTasksProcessed++;
+
+          this.emitEvent('task_processed', {
+            taskId: task.id,
+            taskType: task.type,
+            success: result.success,
+            durationMs: result.durationMs,
+          });
+        } catch (error) {
+          this.emitEvent('error', {
+            taskId: task.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } catch (error) {
+      this.emitEvent('error', {
+        phase: 'task_poll',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async checkpoint(): Promise<void> {
+    this.state.checkpoint = {
+      beatCount: this.state.beatCount,
+      totalTasksProcessed: this.state.totalTasksProcessed,
+      lastBeatAt: this.state.lastBeatAt,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.emitEvent('checkpoint', { checkpoint: this.state.checkpoint });
+  }
+
+  private handleError(error: Error): void {
+    this.state.consecutiveErrors++;
+    this.emitEvent('error', {
+      message: error.message,
+      consecutiveErrors: this.state.consecutiveErrors,
+    });
+
+    if (this.state.consecutiveErrors >= this.config.maxConsecutiveErrors) {
+      this.state.status = 'error';
+      this.clearTimers();
+      this.emitEvent('shutdown', {
+        reason: 'max_consecutive_errors',
+        errors: this.state.consecutiveErrors,
+      });
+    } else {
+      this.scheduleNextBeat();
+    }
+  }
+
+  private emitHealthReport(): void {
+    this.state.lastHealthReportAt = new Date().toISOString();
+    this.emitEvent('health_report', {
+      status: this.state.status,
+      beatCount: this.state.beatCount,
+      tasksProcessed: this.state.totalTasksProcessed,
+      consecutiveErrors: this.state.consecutiveErrors,
+      uptimeMs: this.state.startedAt
+        ? Date.now() - new Date(this.state.startedAt).getTime()
+        : 0,
+    });
+  }
+
+  private emitEvent(
+    type: HeartbeatEvent['type'],
+    data: Record<string, unknown>,
+  ): void {
+    const event: HeartbeatEvent = {
+      type,
+      timestamp: new Date().toISOString(),
+      data,
+    };
+    for (const cb of this.eventCallbacks) {
+      try {
+        cb(event);
+      } catch { }
+    }
+  }
+
+  private clearTimers(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer);
+      this.healthTimer = null;
+    }
+    if (this.taskPollTimer) {
+      clearInterval(this.taskPollTimer);
+      this.taskPollTimer = null;
+    }
+  }
+
+  private registerShutdownHandlers(): void {
+    if (this.shutdownHandlersRegistered) return;
+
+    process.on('SIGTERM', this.shutdownHandler);
+    process.on('SIGINT', this.shutdownHandler);
+    this.shutdownHandlersRegistered = true;
+  }
+
+  private removeShutdownHandlers(): void {
+    if (!this.shutdownHandlersRegistered) return;
+
+    process.off('SIGTERM', this.shutdownHandler);
+    process.off('SIGINT', this.shutdownHandler);
+    this.shutdownHandlersRegistered = false;
+  }
+}
+
+export function createHeartbeatSystem(
+  config?: Partial<HeartbeatConfig>,
+): HeartbeatSystem {
+  return new HeartbeatSystem(config);
+}

--- a/packages/opensin-sdk/src/index.ts
+++ b/packages/opensin-sdk/src/index.ts
@@ -6,6 +6,10 @@
 export { AgentLoop, createAgentLoop, AgentLoopContext } from './agent_loop';
 export type { AgentLoopConfig, AgentLoopResult, ToolHandler } from './agent_loop';
 
+// CLI Agent
+export { CLIAgent, SessionManager, ToolRegistry, createBuiltinTools } from './cli-agent';
+export type { CLIAgentConfig, CLIAgentSession, CLIMessage, CLIContext, CLITool, ToolCallRecord, ToolResult as CLIToolResult, CLICommand, CLICommandOptions, CLIAgentState, CLIEvent } from './cli-agent';
+
 // Model Routing
 export { SmartModelRouter } from './model_routing';
 export type { ModelConfig, RoutingConfig, RoutingDecision, TaskComplexity } from './model_routing';
@@ -52,3 +56,31 @@ export type { SkillMetadata, SkillDefinition, SkillRegistryOptions } from './ski
 // A2A Transport Layer
 export { A2AServer, A2AClient } from './transport';
 export type { A2ATaskPayload, A2ATaskResponse, A2AHealthCheck } from './transport';
+
+// Heartbeat System
+export { HeartbeatSystem, createHeartbeatSystem } from './heartbeat';
+export type { HeartbeatConfig, HeartbeatState, HeartbeatEvent, HeartbeatStatus, QueuedTask, TaskResult, TaskProcessor, TaskQueuePoller } from './heartbeat';
+
+// Failover Model Router
+export { FailoverRouter, createFailoverRouter, OPENSIN_MODELS, DEFAULT_CHAINS } from './model_routing/failover';
+export type { FailoverModelConfig, FailoverChain, FailoverResult, FailoverEvent } from './model_routing/failover';
+
+// Cron Scheduler
+export { CronScheduler, createCronScheduler, parseCronExpression, getNextExecution } from './cron';
+export type { CronTask, CronExecution, CronExecutor, CronEvent } from './cron';
+
+// Approval Hooks
+export { ApprovalHooks, createApprovalHooks, DEFAULT_RULES as DEFAULT_APPROVAL_RULES } from './approval';
+export type { ApprovalRule, ApprovalRequest, ApprovalDecision, ApprovalEvent, RiskLevel, ApprovalCondition } from './approval';
+
+// Agent Orchestrator
+export { AgentOrchestrator, createOrchestrator } from './orchestrator';
+export type { OrchestratorConfig, OrchestratorState, OrchestratorEvent, OrchestratorCallback } from './orchestrator';
+
+// V2 Modules (experimental)
+export * from './hooks_v2';
+export * from './ink_v2';
+export * from './cli_v2';
+export * from './tools_v2';
+export * from './utils_v2';
+export * from './components_v2';

--- a/packages/opensin-sdk/src/model_routing/failover.ts
+++ b/packages/opensin-sdk/src/model_routing/failover.ts
@@ -1,0 +1,380 @@
+/**
+ * OpenSIN Failover Model Router
+ *
+ * Multi-provider failover routing with Antigravity, OCI Proxy, and NVIDIA NIM.
+ * Supports primary → secondary → tertiary model chains with automatic fallback
+ * on rate limits, errors, and capacity issues.
+ */
+
+export interface FailoverModelConfig {
+  id: string;
+  name: string;
+  provider: 'antigravity' | 'openai-oci' | 'nvidia-nim' | 'local' | 'custom';
+  baseURL?: string;
+  capabilities: string[];
+  costPerInputToken: number;
+  costPerOutputToken: number;
+  contextLimit: number;
+  maxOutputTokens: number;
+  latencyProfile: 'fast' | 'medium' | 'slow';
+  reliability: number;
+}
+
+export interface FailoverChain {
+  id: string;
+  name: string;
+  models: FailoverModelConfig[];
+  strategy: 'cost-first' | 'speed-first' | 'quality-first' | 'task-based';
+}
+
+export interface FailoverResult {
+  selectedModel: FailoverModelConfig;
+  chainId: string;
+  attempt: number;
+  fallbackFrom?: string;
+  fallbackReason?: string;
+  estimatedCost: number;
+  estimatedLatencyMs: number;
+}
+
+export interface FailoverEvent {
+  type: 'route' | 'fallback' | 'exhausted' | 'recovered';
+  timestamp: number;
+  chainId: string;
+  modelId: string;
+  data: Record<string, unknown>;
+}
+
+const OPENSIN_MODELS: FailoverModelConfig[] = [
+  {
+    id: 'openai/gpt-5.4',
+    name: 'GPT-5.4 via OCI Proxy',
+    provider: 'openai-oci',
+    baseURL: 'http://92.5.60.87:4100/v1',
+    capabilities: ['tool_use', 'code', 'reasoning', 'vision', 'function_calling', 'json_mode', 'streaming'],
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    contextLimit: 128_000,
+    maxOutputTokens: 16_384,
+    latencyProfile: 'fast',
+    reliability: 0.95,
+  },
+  {
+    id: 'google/antigravity-claude-sonnet-4-6',
+    name: 'Claude Sonnet 4.6 via Antigravity',
+    provider: 'antigravity',
+    capabilities: ['tool_use', 'code', 'reasoning', 'vision', 'function_calling', 'json_mode', 'streaming'],
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    contextLimit: 200_000,
+    maxOutputTokens: 16_384,
+    latencyProfile: 'medium',
+    reliability: 0.92,
+  },
+  {
+    id: 'google/antigravity-gemini-3.1-pro',
+    name: 'Gemini 3.1 Pro via Antigravity',
+    provider: 'antigravity',
+    capabilities: ['tool_use', 'code', 'reasoning', 'vision', 'function_calling', 'json_mode', 'streaming', 'image_generation'],
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    contextLimit: 1_000_000,
+    maxOutputTokens: 65_536,
+    latencyProfile: 'medium',
+    reliability: 0.93,
+  },
+  {
+    id: 'google/antigravity-claude-opus-4-6-thinking',
+    name: 'Claude Opus 4.6 Thinking via Antigravity',
+    provider: 'antigravity',
+    capabilities: ['tool_use', 'code', 'reasoning', 'vision', 'function_calling', 'json_mode', 'streaming', 'extended_thinking'],
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    contextLimit: 200_000,
+    maxOutputTokens: 32_768,
+    latencyProfile: 'slow',
+    reliability: 0.90,
+  },
+  {
+    id: 'google/antigravity-gemini-3-flash',
+    name: 'Gemini 3 Flash via Antigravity',
+    provider: 'antigravity',
+    capabilities: ['tool_use', 'code', 'function_calling', 'json_mode', 'streaming'],
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    contextLimit: 1_000_000,
+    maxOutputTokens: 8_192,
+    latencyProfile: 'fast',
+    reliability: 0.96,
+  },
+  {
+    id: 'nvidia-nim/qwen-3.5-397b',
+    name: 'Qwen 3.5 397B via NVIDIA NIM',
+    provider: 'nvidia-nim',
+    capabilities: ['tool_use', 'code', 'reasoning', 'function_calling', 'json_mode', 'streaming'],
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    contextLimit: 128_000,
+    maxOutputTokens: 16_384,
+    latencyProfile: 'medium',
+    reliability: 0.88,
+  },
+];
+
+const DEFAULT_CHAINS: FailoverChain[] = [
+  {
+    id: 'default',
+    name: 'Default Chain',
+    models: [
+      OPENSIN_MODELS.find(m => m.id === 'openai/gpt-5.4')!,
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-claude-sonnet-4-6')!,
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-gemini-3.1-pro')!,
+    ],
+    strategy: 'quality-first',
+  },
+  {
+    id: 'fast',
+    name: 'Speed-Optimized Chain',
+    models: [
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-gemini-3-flash')!,
+      OPENSIN_MODELS.find(m => m.id === 'openai/gpt-5.4')!,
+      OPENSIN_MODELS.find(m => m.id === 'nvidia-nim/qwen-3.5-397b')!,
+    ],
+    strategy: 'speed-first',
+  },
+  {
+    id: 'reasoning',
+    name: 'Deep Reasoning Chain',
+    models: [
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-claude-opus-4-6-thinking')!,
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-gemini-3.1-pro')!,
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-claude-sonnet-4-6')!,
+    ],
+    strategy: 'quality-first',
+  },
+  {
+    id: 'long-context',
+    name: 'Long Context Chain',
+    models: [
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-gemini-3.1-pro')!,
+      OPENSIN_MODELS.find(m => m.id === 'google/antigravity-gemini-3-flash')!,
+      OPENSIN_MODELS.find(m => m.id === 'openai/gpt-5.4')!,
+    ],
+    strategy: 'quality-first',
+  },
+];
+
+export class FailoverRouter {
+  private chains: Map<string, FailoverChain> = new Map();
+  private activeChainId = 'default';
+  private modelHealth: Map<string, { failures: number; lastFailureAt: number | null; cooldownUntil: number | null }> = new Map();
+  private eventListeners: ((event: FailoverEvent) => void)[] = [];
+  private recentRoutes: FailoverResult[] = [];
+
+  constructor(chains?: FailoverChain[]) {
+    const initialChains = chains || DEFAULT_CHAINS;
+    for (const chain of initialChains) {
+      this.chains.set(chain.id, chain);
+      for (const model of chain.models) {
+        if (!this.modelHealth.has(model.id)) {
+          this.modelHealth.set(model.id, { failures: 0, lastFailureAt: null, cooldownUntil: null });
+        }
+      }
+    }
+  }
+
+  route(
+    prompt: string,
+    options?: {
+      requiresVision?: boolean;
+      requiresReasoning?: boolean;
+      requiresCode?: boolean;
+      requiresLongContext?: boolean;
+      preferSpeed?: boolean;
+      estimatedInputTokens?: number;
+    },
+  ): FailoverResult {
+    const chain = this.selectChain(options);
+    const selectedModel = this.selectModelFromChain(chain, options);
+
+    const estimatedTokens = options?.estimatedInputTokens || Math.ceil(prompt.length / 4);
+    const estimatedCost = estimatedTokens * selectedModel.costPerInputToken;
+
+    const result: FailoverResult = {
+      selectedModel,
+      chainId: chain.id,
+      attempt: 1,
+      estimatedCost,
+      estimatedLatencyMs: this.estimateLatency(selectedModel),
+    };
+
+    this.recentRoutes.push(result);
+    this.emitEvent('route', chain.id, selectedModel.id, { result });
+
+    return result;
+  }
+
+  reportFailure(modelId: string, error: string): void {
+    const health = this.modelHealth.get(modelId);
+    if (!health) return;
+
+    health.failures++;
+    health.lastFailureAt = Date.now();
+    health.cooldownUntil = Date.now() + Math.min(30000 * health.failures, 300000);
+
+    this.emitEvent('fallback', this.activeChainId, modelId, {
+      error,
+      failures: health.failures,
+      cooldownUntil: health.cooldownUntil,
+    });
+  }
+
+  reportSuccess(modelId: string): void {
+    const health = this.modelHealth.get(modelId);
+    if (!health) return;
+
+    health.failures = Math.max(0, health.failures - 1);
+    health.cooldownUntil = null;
+
+    this.emitEvent('recovered', this.activeChainId, modelId, {});
+  }
+
+  getFallback(
+    currentModelId: string,
+    chainId?: string,
+    error?: string,
+  ): FailoverResult | null {
+    const chain = this.chains.get(chainId || this.activeChainId);
+    if (!chain) return null;
+
+    const currentIndex = chain.models.findIndex(m => m.id === currentModelId);
+    if (currentIndex === -1 || currentIndex >= chain.models.length - 1) {
+      this.emitEvent('exhausted', chain.id, currentModelId, { error });
+      return null;
+    }
+
+    for (let i = currentIndex + 1; i < chain.models.length; i++) {
+      const candidate = chain.models[i];
+      const health = this.modelHealth.get(candidate.id);
+
+      if (health?.cooldownUntil && Date.now() < health.cooldownUntil) {
+        continue;
+      }
+
+      return {
+        selectedModel: candidate,
+        chainId: chain.id,
+        attempt: i + 1,
+        fallbackFrom: currentModelId,
+        fallbackReason: error || 'automatic_fallback',
+        estimatedCost: 0,
+        estimatedLatencyMs: this.estimateLatency(candidate),
+      };
+    }
+
+    this.emitEvent('exhausted', chain.id, currentModelId, { error });
+    return null;
+  }
+
+  setActiveChain(chainId: string): void {
+    if (this.chains.has(chainId)) {
+      this.activeChainId = chainId;
+    }
+  }
+
+  addChain(chain: FailoverChain): void {
+    this.chains.set(chain.id, chain);
+    for (const model of chain.models) {
+      if (!this.modelHealth.has(model.id)) {
+        this.modelHealth.set(model.id, { failures: 0, lastFailureAt: null, cooldownUntil: null });
+      }
+    }
+  }
+
+  getChain(chainId: string): FailoverChain | undefined {
+    return this.chains.get(chainId);
+  }
+
+  listChains(): FailoverChain[] {
+    return Array.from(this.chains.values());
+  }
+
+  getModelHealth(modelId: string): { failures: number; lastFailureAt: number | null; cooldownUntil: number | null } | undefined {
+    return this.modelHealth.get(modelId);
+  }
+
+  getRecentRoutes(limit = 20): FailoverResult[] {
+    return this.recentRoutes.slice(-limit);
+  }
+
+  onEvent(listener: (event: FailoverEvent) => void): () => void {
+    this.eventListeners.push(listener);
+    return () => {
+      this.eventListeners = this.eventListeners.filter(l => l !== listener);
+    };
+  }
+
+  private selectChain(options?: {
+    requiresVision?: boolean;
+    requiresReasoning?: boolean;
+    requiresLongContext?: boolean;
+    preferSpeed?: boolean;
+  }): FailoverChain {
+    if (options?.preferSpeed) {
+      return this.chains.get('fast') || this.chains.get(this.activeChainId)!;
+    }
+    if (options?.requiresReasoning) {
+      return this.chains.get('reasoning') || this.chains.get(this.activeChainId)!;
+    }
+    if (options?.requiresLongContext) {
+      return this.chains.get('long-context') || this.chains.get(this.activeChainId)!;
+    }
+    return this.chains.get(this.activeChainId)!;
+  }
+
+  private selectModelFromChain(chain: FailoverChain, options?: {
+    requiresVision?: boolean;
+    requiresCode?: boolean;
+    estimatedInputTokens?: number;
+  }): FailoverModelConfig {
+    for (const model of chain.models) {
+      const health = this.modelHealth.get(model.id);
+      if (health?.cooldownUntil && Date.now() < health.cooldownUntil) {
+        continue;
+      }
+      if (options?.requiresVision && !model.capabilities.includes('vision')) {
+        continue;
+      }
+      if (options?.requiresCode && !model.capabilities.includes('code')) {
+        continue;
+      }
+      if (options?.estimatedInputTokens && options.estimatedInputTokens > model.contextLimit) {
+        continue;
+      }
+      return model;
+    }
+    return chain.models[0];
+  }
+
+  private estimateLatency(model: FailoverModelConfig): number {
+    const baseLatencies: Record<string, number> = {
+      fast: 500,
+      medium: 2000,
+      slow: 5000,
+    };
+    return baseLatencies[model.latencyProfile] || 2000;
+  }
+
+  private emitEvent(type: FailoverEvent['type'], chainId: string, modelId: string, data: Record<string, unknown>): void {
+    const event: FailoverEvent = { type, timestamp: Date.now(), chainId, modelId, data };
+    for (const listener of this.eventListeners) {
+      try { listener(event); } catch { }
+    }
+  }
+}
+
+export function createFailoverRouter(chains?: FailoverChain[]): FailoverRouter {
+  return new FailoverRouter(chains);
+}
+
+export { OPENSIN_MODELS, DEFAULT_CHAINS };

--- a/packages/opensin-sdk/src/orchestrator/index.ts
+++ b/packages/opensin-sdk/src/orchestrator/index.ts
@@ -1,0 +1,402 @@
+/**
+ * OpenSIN Agent Orchestrator — Unified integration layer
+ *
+ * Connects all Sprint 1 systems:
+ * - HeartbeatSystem ↔ AgentLoop (periodic autonomous check-in)
+ * - CronScheduler ↔ LoopMode (scheduled recurring tasks)
+ * - FailoverRouter ↔ SmartModelRouter (multi-provider failover)
+ * - ApprovalHooks ↔ PermissionEvaluator (risk-based safety gates)
+ *
+ * This is the main entry point for building a fully autonomous OpenSIN agent.
+ */
+
+import { HeartbeatSystem, createHeartbeatSystem } from '../heartbeat/index.js';
+import type { HeartbeatConfig, HeartbeatEvent, TaskProcessor, TaskQueuePoller, QueuedTask, TaskResult } from '../heartbeat/index.js';
+
+import { CronScheduler, createCronScheduler } from '../cron/index.js';
+import type { CronTask, CronExecutor, CronEvent } from '../cron/index.js';
+
+import { FailoverRouter, createFailoverRouter } from '../model_routing/failover.js';
+import type { FailoverChain, FailoverEvent, FailoverResult } from '../model_routing/failover.js';
+
+import { ApprovalHooks, createApprovalHooks } from '../approval/index.js';
+import type { ApprovalRule, ApprovalEvent, ApprovalDecision, RiskLevel } from '../approval/index.js';
+
+import { SmartModelRouter } from '../model_routing/router.js';
+import type { RoutingConfig, RoutingDecision } from '../model_routing/types.js';
+
+import { AgentLoop } from '../agent_loop/agent_loop.js';
+import type { AgentLoopConfig, LLMCaller, LLMResponse } from '../agent_loop/types.js';
+
+import { LoopMode } from '../loop/index.js';
+import type { LoopConfig, LoopState } from '../loop/models.js';
+
+import { PermissionEvaluator } from '../permissions/evaluator.js';
+import type { PermissionRule, PermissionCheck, PermissionResult } from '../permissions/types.js';
+
+export interface OrchestratorConfig {
+  heartbeat?: Partial<HeartbeatConfig>;
+  cronCheckIntervalMs?: number;
+  failoverChains?: FailoverChain[];
+  approvalRules?: ApprovalRule[];
+  routingConfig?: Partial<RoutingConfig>;
+  agentLoopConfig?: Partial<AgentLoopConfig>;
+  permissionRules?: PermissionRule[];
+}
+
+export interface OrchestratorState {
+  status: 'idle' | 'running' | 'paused' | 'error' | 'shutting_down';
+  heartbeatStatus: import('../heartbeat/index.js').HeartbeatStatus;
+  cronTaskCount: number;
+  activeChainId: string;
+  totalApprovals: number;
+  pendingApprovals: number;
+  startedAt: string | null;
+  uptimeMs: number;
+}
+
+export interface OrchestratorEvent {
+  type:
+    | 'started'
+    | 'stopped'
+    | 'paused'
+    | 'resumed'
+    | 'heartbeat_beat'
+    | 'cron_execution'
+    | 'failover_fallback'
+    | 'approval_required'
+    | 'approval_resolved'
+    | 'error';
+  timestamp: string;
+  data: Record<string, unknown>;
+}
+
+export type OrchestratorCallback = (event: OrchestratorEvent) => void | Promise<void>;
+
+export class AgentOrchestrator {
+  private heartbeat: HeartbeatSystem;
+  private cron: CronScheduler;
+  private failover: FailoverRouter;
+  private approval: ApprovalHooks;
+  private router: SmartModelRouter;
+  private permissionEval: PermissionEvaluator;
+  private agentLoop: AgentLoop | null = null;
+  private loopMode: LoopMode | null = null;
+  private llmCaller: LLMCaller | null = null;
+  private eventCallbacks: OrchestratorCallback[] = [];
+  private startedAt: string | null = null;
+  private status: OrchestratorState['status'] = 'idle';
+
+  constructor(config?: OrchestratorConfig) {
+    this.heartbeat = createHeartbeatSystem(config?.heartbeat);
+    this.cron = createCronScheduler(undefined, config?.cronCheckIntervalMs);
+    this.failover = createFailoverRouter(config?.failoverChains);
+    this.approval = createApprovalHooks(config?.approvalRules);
+    this.router = new SmartModelRouter(config?.routingConfig);
+    this.permissionEval = new PermissionEvaluator(config?.permissionRules || []);
+
+    this.wireInternalEvents();
+  }
+
+  setLLMCaller(caller: LLMCaller): void {
+    this.llmCaller = caller;
+  }
+
+  setAgentLoop(loop: AgentLoop): void {
+    this.agentLoop = loop;
+  }
+
+  setLoopMode(loopMode: LoopMode): void {
+    this.loopMode = loopMode;
+  }
+
+  setTaskQueuePoller(poller: TaskQueuePoller): void {
+    this.heartbeat.setTaskQueuePoller(poller);
+  }
+
+  setTaskProcessor(processor: TaskProcessor): void {
+    this.heartbeat.setTaskProcessor(processor);
+  }
+
+  setNotificationChannel(channel: (request: import('../approval/index.js').ApprovalRequest) => Promise<void>): void {
+    this.approval.setNotificationChannel(channel);
+  }
+
+  addCronTask(config: Omit<CronTask, 'id' | 'executionCount' | 'lastExecutedAt' | 'nextExecutionAt' | 'createdAt'>): CronTask {
+    return this.cron.createTask(config);
+  }
+
+  addApprovalRule(rule: ApprovalRule): void {
+    this.approval.addRule(rule);
+  }
+
+  addPermissionRule(rule: PermissionRule): void {
+    this.permissionEval.addRule(rule);
+  }
+
+  async evaluateAction(action: string, input: Record<string, unknown>): Promise<{
+    approved: boolean;
+    riskLevel: RiskLevel;
+    requestId?: string;
+    ruleId?: string;
+    permissionResult?: PermissionResult;
+  }> {
+    const approvalResult = await this.approval.evaluateAction(action, input);
+
+    const permCheck: PermissionCheck = {
+      toolName: action,
+      args: input,
+    };
+    const permissionResult = await this.permissionEval.checkPermission(permCheck);
+
+    if (!approvalResult.approved) {
+      this.emitOrchestratorEvent('approval_required', {
+        action,
+        requestId: approvalResult.requestId,
+        riskLevel: approvalResult.riskLevel,
+      });
+    }
+
+    const approved = approvalResult.approved && permissionResult.decision !== 'deny';
+
+    return {
+      approved,
+      riskLevel: approvalResult.riskLevel,
+      requestId: approvalResult.requestId,
+      ruleId: approvalResult.ruleId,
+      permissionResult,
+    };
+  }
+
+  resolveApproval(decision: ApprovalDecision): import('../approval/index.js').ApprovalRequest | null {
+    const result = this.approval.resolveRequest(decision);
+    if (result) {
+      this.emitOrchestratorEvent('approval_resolved', {
+        requestId: decision.requestId,
+        decision: decision.decision,
+        resolvedBy: decision.resolvedBy,
+      });
+    }
+    return result;
+  }
+
+  routeModel(prompt: string, options?: {
+    requiresVision?: boolean;
+    requiresReasoning?: boolean;
+    requiresCode?: boolean;
+    requiresLongContext?: boolean;
+    preferSpeed?: boolean;
+    estimatedInputTokens?: number;
+    requiresToolUse?: boolean;
+  }): FailoverResult & { routingDecision?: RoutingDecision } {
+    const failoverResult = this.failover.route(prompt, options);
+
+    const routingDecision = this.router.route(prompt, options?.requiresToolUse);
+
+    return {
+      ...failoverResult,
+      routingDecision,
+    };
+  }
+
+  reportModelFailure(modelId: string, error: string): void {
+    this.failover.reportFailure(modelId, error);
+    this.emitOrchestratorEvent('failover_fallback', { modelId, error });
+  }
+
+  reportModelSuccess(modelId: string): void {
+    this.failover.reportSuccess(modelId);
+  }
+
+  start(): OrchestratorState {
+    if (this.status === 'running') return this.getState();
+
+    this.wireCronExecutor();
+
+    this.heartbeat.start();
+    this.cron.start();
+
+    this.status = 'running';
+    this.startedAt = new Date().toISOString();
+
+    this.emitOrchestratorEvent('started', {});
+    return this.getState();
+  }
+
+  pause(): OrchestratorState {
+    this.heartbeat.pause();
+    this.cron.stop();
+    this.status = 'paused';
+    this.emitOrchestratorEvent('paused', {});
+    return this.getState();
+  }
+
+  resume(): OrchestratorState {
+    this.heartbeat.resume();
+    this.cron.start();
+    this.status = 'running';
+    this.emitOrchestratorEvent('resumed', {});
+    return this.getState();
+  }
+
+  async stop(): Promise<OrchestratorState> {
+    this.cron.stop();
+    await this.heartbeat.gracefulShutdown();
+    this.approval.destroy();
+    this.status = 'idle';
+    this.emitOrchestratorEvent('stopped', {});
+    return this.getState();
+  }
+
+  getState(): OrchestratorState {
+    const hbState = this.heartbeat.getState();
+    return {
+      status: this.status,
+      heartbeatStatus: hbState.status,
+      cronTaskCount: this.cron.listTasks(true).length,
+      activeChainId: this.failover.getChain('default') ? 'default' : 'none',
+      totalApprovals: this.approval.getAuditLog().length,
+      pendingApprovals: this.approval.getPendingRequests().length,
+      startedAt: this.startedAt,
+      uptimeMs: this.startedAt ? Date.now() - new Date(this.startedAt).getTime() : 0,
+    };
+  }
+
+  getHeartbeat(): HeartbeatSystem {
+    return this.heartbeat;
+  }
+
+  getCron(): CronScheduler {
+    return this.cron;
+  }
+
+  getFailover(): FailoverRouter {
+    return this.failover;
+  }
+
+  getApproval(): ApprovalHooks {
+    return this.approval;
+  }
+
+  getRouter(): SmartModelRouter {
+    return this.router;
+  }
+
+  getPermissionEvaluator(): PermissionEvaluator {
+    return this.permissionEval;
+  }
+
+  onEvent(callback: OrchestratorCallback): () => void {
+    this.eventCallbacks.push(callback);
+    return () => {
+      this.eventCallbacks = this.eventCallbacks.filter(cb => cb !== callback);
+    };
+  }
+
+  private wireCronExecutor(): void {
+    this.cron.setExecutor(async (prompt: string, task: CronTask) => {
+      if (!this.llmCaller) {
+        throw new Error('No LLM caller configured. Call setLLMCaller() first.');
+      }
+
+      const evaluation = await this.evaluateAction('cron_execute', {
+        prompt,
+        taskId: task.id,
+        cronExpression: task.cronExpression,
+      });
+
+      if (!evaluation.approved) {
+        throw new Error(`Cron task ${task.id} blocked by approval/permission system`);
+      }
+
+      const routeResult = this.routeModel(prompt, {
+        preferSpeed: true,
+        requiresToolUse: true,
+      });
+
+      const response = await this.llmCaller(
+        [{ role: 'user', content: prompt }],
+        [],
+      );
+
+      this.reportModelSuccess(routeResult.selectedModel.id);
+
+      return response.content || '';
+    });
+  }
+
+  private wireInternalEvents(): void {
+    this.heartbeat.onEvent((event: HeartbeatEvent) => {
+      if (event.type === 'beat') {
+        this.emitOrchestratorEvent('heartbeat_beat', {
+          beatCount: event.data.beatCount,
+          tasksProcessed: event.data.tasksProcessed,
+        });
+      } else if (event.type === 'error') {
+        this.emitOrchestratorEvent('error', {
+          source: 'heartbeat',
+          ...event.data,
+        });
+      }
+    });
+
+    this.cron.onEvent((event: CronEvent) => {
+      if (event.type === 'task_started') {
+        this.emitOrchestratorEvent('cron_execution', {
+          taskId: event.taskId,
+          phase: 'started',
+          ...event.data,
+        });
+      } else if (event.type === 'task_completed') {
+        this.emitOrchestratorEvent('cron_execution', {
+          taskId: event.taskId,
+          phase: 'completed',
+          ...event.data,
+        });
+      } else if (event.type === 'task_failed') {
+        this.emitOrchestratorEvent('error', {
+          source: 'cron',
+          taskId: event.taskId,
+          ...event.data,
+        });
+      }
+    });
+
+    this.failover.onEvent((event: FailoverEvent) => {
+      if (event.type === 'fallback') {
+        this.emitOrchestratorEvent('failover_fallback', {
+          modelId: event.modelId,
+          chainId: event.chainId,
+          ...event.data,
+        });
+      } else if (event.type === 'exhausted') {
+        this.emitOrchestratorEvent('error', {
+          source: 'failover',
+          modelId: event.modelId,
+          chainId: event.chainId,
+          ...event.data,
+        });
+      }
+    });
+
+    this.approval.onEvent((event: ApprovalEvent) => {
+      if (event.type === 'request_created') {
+        this.emitOrchestratorEvent('approval_required', {
+          requestId: event.requestId,
+          ...event.data,
+        });
+      }
+    });
+  }
+
+  private emitOrchestratorEvent(type: OrchestratorEvent['type'], data: Record<string, unknown>): void {
+    const event: OrchestratorEvent = { type, timestamp: new Date().toISOString(), data };
+    for (const cb of this.eventCallbacks) {
+      try { cb(event); } catch {}
+    }
+  }
+}
+
+export function createOrchestrator(config?: OrchestratorConfig): AgentOrchestrator {
+  return new AgentOrchestrator(config);
+}


### PR DESCRIPTION
## Summary
- Add heartbeat, cron, failover, and approval subsystems for autonomous runtime control.
- Introduce `AgentOrchestrator` and wire the CLI agent through it for routing and policy checks.
- Add focused tests for each subsystem and the CLI agent integration.

## Verification
- `npx vitest run src/__tests__/heartbeat.test.ts src/__tests__/cron.test.ts src/__tests__/failover.test.ts src/__tests__/approval.test.ts src/__tests__/orchestrator.test.ts src/__tests__/cli_agent_orchestrator.test.ts --config src/__tests__/vitest.config.ts`
- `npx tsc --noEmit` (0 errors in the new modules)

Closes #1077