### PR TITLE
docs: remove Antigravity Rotator refs from OpenSIN-Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 ## Features
 
 - **AI-Powered Coding**: Autonomous code generation, refactoring, and debugging
-- **Antigravity Rotator 2.0 (God-Level)**: Supercharged by 12-phase fleet capabilities (Subagents, Auto-PRs, Multi-Cloud, Telegram Self-Healing, Idle Monetization)
 - **OpenSIN Bridge**: Chrome Extension mit 39 MCP Tools, besser als Antigravity
 - **sinInChrome Integration**: Browser automation via MCP (13 actions, 7 browsers)
 - **sin-computer-use Integration**: macOS GUI automation (screen capture, input, app management)


### PR DESCRIPTION
Reverts the Antigravity Rotator feature note from OpenSIN-Code so the CLI docs only cover OpenSIN-Code features.