### PR TITLE
feat: add CODEOWNERS per E1 Engineering Standards (CEO Directive #40)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# OpenSIN-Code Code Owners
+* @OpenSIN-AI/core-team


### PR DESCRIPTION
## Summary

Adds  to [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) — part of **Enabler E1** (CEO Directive #40).

Canonical template sourced from [OpenSIN-documentation/CODEOWNERS](https://github.com/OpenSIN-AI/OpenSIN-documentation/blob/main/CODEOWNERS).

### Coverage

| Path | Owner |
|------|-------|
|  (root) | @OpenSIN-AI/core-team |
|  | @OpenSIN-AI/core-team |
|  | @OpenSIN-AI/core-team |
|  | @OpenSIN-AI/core-team |
|  | @OpenSIN-AI/core-team |

### Verification

```bash
# Should return CODEOWNERS
gh api repos/OpenSIN-AI/OpenSIN-Code/contents/CODEOWNERS --jq '.name'
```

Closes OpenSIN-overview#41 (Enabler E1)